### PR TITLE
Draft: Add assets and code for missing infested blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 
-version = '1.20.1-0.8.0'
+version = '1.20.1-0.8.1-Beta1'
 group = 'com.github.sculkhorde' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'sculkhorde'
 

--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTable.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTable.java
@@ -1,22 +1,14 @@
 package com.github.sculkhorde.common.block.InfestationEntries;
 
-import com.github.sculkhorde.common.block.SculkNodeBlock;
-import com.github.sculkhorde.core.ModBlocks;
 import com.github.sculkhorde.util.BlockAlgorithms;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.IPlantable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,11 +17,22 @@ public class BlockInfestationTable{
 
     private List<IBlockInfestationEntry> entries;
 
-    public BlockInfestationTable()
+    public BlockInfestationTable(boolean denyNonSolidBlocks)
     {
         entries = new ArrayList<>();
+        setDenyNonSolidBlocks(denyNonSolidBlocks);
     }
 
+    protected boolean denyNonSolidBlocks = true;
+
+
+    public boolean isDenyNonSolidBlocks() {
+    	return denyNonSolidBlocks;
+    }
+
+    public void setDenyNonSolidBlocks(boolean denyNonSolidBlocks) {
+    	this.denyNonSolidBlocks = denyNonSolidBlocks;
+    }
 
     /**
      * Adds a new entry to the table.
@@ -77,16 +80,16 @@ public class BlockInfestationTable{
 
     /**
      * Checks if a block is a normal variant.
-     * @param blockState The block to check.
      * @return True if the block is a normal variant.
      */
-    public boolean isInfectable(BlockState blockState)
+    public boolean canBeInfectedByThisTable(ServerLevel level, BlockPos pos)
     {
-        if(blockState.is(ModBlocks.BlockTags.NOT_INFESTABLE))
-        {
-            return false;
-        }
-        else if( blockState.is(ModBlocks.BlockTags.INFESTED_BLOCK))
+        BlockState blockState = level.getBlockState(pos);
+
+        // If we are denying non-solid blocks, then we need to check if the block is solid.
+        boolean areWeDenyingNonSolidBlocks = isDenyNonSolidBlocks();
+        boolean isBlockNotSolid = BlockAlgorithms.isNotSolid(level, pos);
+        if(areWeDenyingNonSolidBlocks && isBlockNotSolid)
         {
             return false;
         }
@@ -102,49 +105,6 @@ public class BlockInfestationTable{
     }
 
     /**
-     * Checks if a block is an infected variant.
-     * @param blockState The block to check.
-     * @return True if the block is an infected variant.
-     */
-    public boolean isCurable(BlockState blockState)
-    {
-        for(IBlockInfestationEntry entry : entries)
-        {
-            if(entry.isInfectedVariant(blockState))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void removeNearbyVein(ServerLevel world, BlockPos position)
-    {
-        // Update each adjacent block if it is a sculk vein
-        // This is to prevent vein from staying on blocks that it does not belong on.
-        List<BlockPos> adjacentBlockPos = BlockAlgorithms.getAdjacentNeighbors(position);
-        for(BlockPos neighbors : adjacentBlockPos)
-        {
-            BlockState blockState = world.getBlockState(neighbors);
-            if(blockState.getBlock() == ModBlocks.TENDRILS.get())
-            {
-                if(!blockState.getBlock().canSurvive(blockState, world, neighbors))
-                    world.destroyBlock(neighbors, false);
-
-            }
-        }
-    }
-
-    private void placeSculkFlora(ServerLevel world, BlockPos position)
-    {
-        // Given a 25% chance, place down sculk flora on block
-        if (world.random.nextInt(4) <= 0)
-        {
-            BlockAlgorithms.tryPlaceSculkFlora(position.above(), world);
-        }
-    }
-
-    /**
      * This Method serves the purpose of converting a victim block into a dormant variant.
      * This is only a temporary method until I fully design the new infestation system.
      * @param world The world of the block.
@@ -152,7 +112,7 @@ public class BlockInfestationTable{
      */
     public boolean infectBlock(ServerLevel world, BlockPos targetPos)
     {
-        if(world == null || !isInfectable(world.getBlockState(targetPos)))
+        if(world == null || !canBeInfectedByThisTable(world, targetPos))
         {
             return false;
         }
@@ -165,58 +125,13 @@ public class BlockInfestationTable{
             return false;
         }
 
-
         world.setBlockAndUpdate(targetPos, newBlock);
-        world.sendParticles(ParticleTypes.SCULK_CHARGE_POP, targetPos.getX() + 0.5D, targetPos.getY() + 1.15D, targetPos.getZ() + 0.5D, 2, 0.2D, 0.0D, 0.2D, 0.0D);
-        world.playSound((Player)null, targetPos, SoundEvents.SCULK_BLOCK_SPREAD, SoundSource.BLOCKS, 2.0F, 0.6F + 1.0F);
 
         if(newBlock.getBlock() instanceof ITagInfestedBlock)
         {
             ((ITagInfestedBlock) newBlock.getBlock()).getTagInfestedBlockEntity(world, targetPos).setNormalBlockState(oldBlock);
         }
 
-
-        removeNearbyVein(world, targetPos);
-
-        placeSculkFlora(world, targetPos);
-
-        // Chance to place a sculk node above the block
-        SculkNodeBlock.tryPlaceSculkNode(world, targetPos, false);
-
-        // Chance to place a sculk bee hive above the block
-        BlockAlgorithms.tryPlaceSculkBeeHive(world, targetPos.above());
-
         return true;
-    }
-
-    /**
-     * Converts a an active or dormant variant into a victim variant
-     * @param world The world of the block.
-     * @param targetPos The position of the block we are trying to convert.
-     */
-    public boolean cureBlock(ServerLevel world, BlockPos targetPos)
-    {
-        if(world == null || !isCurable(world.getBlockState(targetPos)))
-        {
-            return false;
-        }
-
-        BlockState targetBlock = world.getBlockState(targetPos);
-        BlockState curedVersion = getNormalVariant(world, targetPos, targetBlock);
-
-        if(curedVersion == null)
-        {
-            //SculkHorde.LOGGER.error("Error Deinfecting Block: " + targetBlock.getBlock().toString());
-            return false;
-        }
-
-        BlockState victimVariant = curedVersion;
-
-        if(victimVariant != null)
-        {
-            world.setBlockAndUpdate(targetPos, victimVariant);
-            return true;
-        }
-        return false;
     }
 }

--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTableEntry.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTableEntry.java
@@ -4,13 +4,23 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
 
 public class BlockInfestationTableEntry implements IBlockInfestationEntry
 {
     protected Block normalVariant;
     protected BlockState infectedVariant;
 
-
+    // This is needed to tell java that the properties are of the same type
+    private static <T extends Comparable<T>> BlockState copyBlockProperty(BlockState from, BlockState to, Property<T> property) {
+    	// copy only if from and to have the same Property (this solution is a little bit hacky but I don't no a better way)
+    	try {
+    		return to.setValue(property, from.getValue(property));
+    	} catch(IllegalArgumentException e) {
+    		return to;
+    	}
+    }
+    
     // Default constructor
     public BlockInfestationTableEntry(Block normalVariantIn, BlockState infectedVariantIn)
     {
@@ -35,6 +45,11 @@ public class BlockInfestationTableEntry implements IBlockInfestationEntry
 
     public BlockState getInfectedVariant(Level level, BlockPos blockPos, BlockState blockState)
     {
-        return infectedVariant;
+    	// copy block properties of normal block to infected block
+    	for(Property<?> prop : blockState.getProperties()) {
+    		this.infectedVariant = copyBlockProperty(blockState, this.infectedVariant, prop);
+    	}
+    	
+        return this.infectedVariant;
     }
 }

--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTableEntry.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockInfestationTableEntry.java
@@ -40,7 +40,14 @@ public class BlockInfestationTableEntry implements IBlockInfestationEntry
 
     public BlockState getNormalVariant(Level level, BlockPos blockPos, BlockState blockState)
     {
-        return normalVariant.defaultBlockState();
+    	// In this case we need to copy all the properties again
+    	BlockState normalState = normalVariant.defaultBlockState();
+    	
+    	for(Property<?> prop : blockState.getProperties()) {
+    		normalState = copyBlockProperty(blockState, normalState, prop);
+    	}
+    	
+        return normalState;
     }
 
     public BlockState getInfectedVariant(Level level, BlockPos blockPos, BlockState blockState)

--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockTagInfestationTableEntry.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockTagInfestationTableEntry.java
@@ -1,16 +1,28 @@
 package com.github.sculkhorde.common.block.InfestationEntries;
 
+import com.google.common.collect.ImmutableMap;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
 
 public class BlockTagInfestationTableEntry implements IBlockInfestationEntry
 {
     protected TagKey<Block> normalVariantTag;
     protected ITagInfestedBlock infectedVariant;
 
+    // This is needed to tell java that the properties are of the same type
+    private static <T extends Comparable<T>> BlockState copyBlockProperty(BlockState from, BlockState to, Property<T> property) {
+    	// copy only if from and to have the same Property (this solution is a little bit hacky but I don't no a better way)
+    	try {
+    		return to.setValue(property, from.getValue(property));
+    	} catch(IllegalArgumentException e) {
+    		return to;
+    	}
+    }
 
     // Default constructor
     public BlockTagInfestationTableEntry(TagKey<Block> normalVariantIn, ITagInfestedBlock infectedVariantIn)
@@ -41,6 +53,13 @@ public class BlockTagInfestationTableEntry implements IBlockInfestationEntry
 
     public BlockState getInfectedVariant(Level level, BlockPos blockPos, BlockState blockState)
     {
-        return ((Block)infectedVariant).defaultBlockState();
+    	// copy block properties of normal block to infected block
+    	BlockState infectedState = ((Block)infectedVariant).defaultBlockState();
+    	
+    	for(Property<?> prop : blockState.getProperties()) {
+    		infectedState = copyBlockProperty(blockState, infectedState, prop);
+    	}
+    	
+        return infectedState;
     }
 }

--- a/src/main/java/com/github/sculkhorde/common/block/InfestedStairBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestedStairBlock.java
@@ -1,0 +1,66 @@
+package com.github.sculkhorde.common.block;
+
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import com.github.sculkhorde.common.block.InfestationEntries.ITagInfestedBlock;
+import com.github.sculkhorde.common.block.InfestationEntries.ITagInfestedBlockEntity;
+import com.github.sculkhorde.common.blockentity.InfestedTagBlockEntity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.StairBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.extensions.IForgeBlock;
+
+public class InfestedStairBlock extends StairBlock implements EntityBlock, IForgeBlock, ITagInfestedBlock {
+	
+	public InfestedStairBlock(Properties properties) {
+		this(() -> InfestedStairBlock.stateById(0), properties);
+	}
+
+	public InfestedStairBlock(Supplier<BlockState> state, Properties properties) {
+		super(state, properties);
+	}
+	
+	/* Properties from BaseEntityBlock */
+	
+	// Copy default event triggering (not entirely sure if this is actually used)
+    public boolean triggerEvent(BlockState p_49226_, Level p_49227_, BlockPos p_49228_, int p_49229_, int p_49230_) {
+    	super.triggerEvent(p_49226_, p_49227_, p_49228_, p_49229_, p_49230_);
+    	BlockEntity blockentity = p_49227_.getBlockEntity(p_49228_);
+    	return blockentity == null ? false : blockentity.triggerEvent(p_49229_, p_49230_);
+    }
+    
+    // Copy entity ticking
+    @Nullable
+    protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> p_152133_, BlockEntityType<E> p_152134_, BlockEntityTicker<? super E> p_152135_) {
+       return p_152134_ == p_152133_ ? (BlockEntityTicker<A>)p_152135_ : null;
+    }
+	
+	/* Properties from InfestedTagBlock */
+	@Override
+    public boolean isRandomlyTicking(BlockState blockState) {
+        return false;
+    }
+
+	@Override
+    public BlockEntity newBlockEntity(BlockPos blockPos, BlockState state) {
+        return new InfestedTagBlockEntity(blockPos, state);
+    }
+	
+	@Override
+    public ITagInfestedBlockEntity getTagInfestedBlockEntity(Level level, BlockPos blockPos) {
+        BlockEntity blockEntity = level.getBlockEntity(blockPos);
+        if(blockEntity instanceof ITagInfestedBlockEntity)
+        {
+            return (ITagInfestedBlockEntity) blockEntity;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/sculkhorde/common/block/SculkFloraBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/block/SculkFloraBlock.java
@@ -2,6 +2,7 @@ package com.github.sculkhorde.common.block;
 
 import com.github.sculkhorde.core.ModParticles;
 import com.github.sculkhorde.core.SculkHorde;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluid;
@@ -123,7 +124,7 @@ public class SculkFloraBlock extends BushBlock implements IForgeBlock {
     @Override
     protected boolean mayPlaceOn(BlockState blockState, BlockGetter iBlockReader, BlockPos pos) {
 
-        return SculkHorde.blockInfestationTable.isCurable(blockState);
+        return BlockInfestationHelper.isCurable(blockState);
     }
 
 
@@ -193,6 +194,6 @@ public class SculkFloraBlock extends BushBlock implements IForgeBlock {
 
     @Override
     public boolean canSurvive(BlockState blockState, LevelReader levelReader, BlockPos blockPos) {
-        return SculkHorde.blockInfestationTable.isCurable(levelReader.getBlockState(blockPos.below()));
+        return BlockInfestationHelper.isCurable(levelReader.getBlockState(blockPos.below()));
     }
 }

--- a/src/main/java/com/github/sculkhorde/common/block/TendrilsBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/block/TendrilsBlock.java
@@ -2,6 +2,7 @@ package com.github.sculkhorde.common.block;
 
 import com.github.sculkhorde.core.ModBlocks;
 import com.github.sculkhorde.core.SculkHorde;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -155,7 +156,7 @@ public class TendrilsBlock extends VineBlock implements IForgeBlock {
         {
             return false;
         }
-        else if(SculkHorde.blockInfestationTable.isCurable(blockState))
+        else if(BlockInfestationHelper.isCurable(blockState))
         {
             return false;
         }

--- a/src/main/java/com/github/sculkhorde/common/blockentity/SculkAncientNodeBlockEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/blockentity/SculkAncientNodeBlockEntity.java
@@ -7,6 +7,7 @@ import com.github.sculkhorde.common.entity.SculkSporeSpewerEntity;
 import com.github.sculkhorde.common.entity.infection.SculkNodeInfectionHandler;
 import com.github.sculkhorde.core.*;
 import com.github.sculkhorde.util.AdvancementUtil;
+import com.github.sculkhorde.util.BlockAlgorithms;
 import com.github.sculkhorde.util.ChunkLoading.BlockEntityChunkLoaderHelper;
 import com.github.sculkhorde.util.TickUnits;
 import com.mojang.serialization.Dynamic;
@@ -75,7 +76,7 @@ public class SculkAncientNodeBlockEntity extends BlockEntity implements GameEven
      */
     public boolean isValidSpawnPosition(ServerLevel worldIn, BlockPos pos)
     {
-        return worldIn.getBlockState(pos.below()).isSolid()  &&
+        return BlockAlgorithms.isSolid(worldIn, pos.below()) &&
                 worldIn.getBlockState(pos).canBeReplaced(Fluids.WATER) &&
                 worldIn.getBlockState(pos).canBeReplaced(Fluids.WATER) &&
                 worldIn.getBlockState(pos.above()).canBeReplaced(Fluids.WATER);

--- a/src/main/java/com/github/sculkhorde/common/blockentity/SculkSummonerBlockEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/blockentity/SculkSummonerBlockEntity.java
@@ -5,6 +5,7 @@ import com.github.sculkhorde.core.ModBlockEntities;
 import com.github.sculkhorde.core.ModBlocks;
 import com.github.sculkhorde.core.SculkHorde;
 import com.github.sculkhorde.core.gravemind.entity_factory.ReinforcementRequest;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import com.github.sculkhorde.util.EntityAlgorithms;
 import com.github.sculkhorde.util.TargetParameters;
 import com.mojang.serialization.Dynamic;
@@ -308,7 +309,7 @@ public class SculkSummonerBlockEntity extends BlockEntity implements GameEventLi
      */
     public boolean isValidSpawnPosition(ServerLevel worldIn, BlockPos pos)
     {
-        return SculkHorde.blockInfestationTable.isCurable(worldIn.getBlockState(pos.below()))  &&
+        return BlockInfestationHelper.isCurable(worldIn.getBlockState(pos.below()))  &&
             worldIn.getBlockState(pos).canBeReplaced(Fluids.WATER) &&
             worldIn.getBlockState(pos.above()).canBeReplaced(Fluids.WATER);
 

--- a/src/main/java/com/github/sculkhorde/common/entity/SculkBeeInfectorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/SculkBeeInfectorEntity.java
@@ -5,6 +5,7 @@ import com.github.sculkhorde.core.ModConfig;
 import com.github.sculkhorde.core.ModEntities;
 import com.github.sculkhorde.core.SculkHorde;
 import com.github.sculkhorde.util.BlockAlgorithms;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
@@ -78,7 +79,7 @@ public class SculkBeeInfectorEntity extends SculkBeeHarvesterEntity implements G
             return false;
         }
 
-        if(!SculkHorde.blockInfestationTable.isInfectable(level().getBlockState(blockPos)))
+        if(!BlockInfestationHelper.isInfectable((ServerLevel) level(), blockPos))
         {
             return false;
         }

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorEntity.java
@@ -106,11 +106,7 @@ public abstract class CursorEntity extends Entity
             return false;
         }
 
-        if(!state.isSolidRender(this.level(), pos))
-        {
-            return true;
-        }
-        else if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
+        if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return true;
         }

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorInfectorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorInfectorEntity.java
@@ -1,14 +1,12 @@
 package com.github.sculkhorde.common.entity.infection;
 
 import com.github.sculkhorde.core.*;
-import com.github.sculkhorde.util.BlockAlgorithms;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-
-import static com.github.sculkhorde.util.BlockAlgorithms.isExposedToInfestationWardBlock;
 
 /** This Entity is used to traverse the world and infect blocks.
  * Once spawned, it will use breadth-first search to find the nearest block to infect.
@@ -46,7 +44,7 @@ public class CursorInfectorEntity extends CursorEntity
     @Override
     protected boolean isTarget(BlockState state, BlockPos pos)
     {
-        return SculkHorde.blockInfestationTable.isInfectable(state);
+        return BlockInfestationHelper.isInfectable((ServerLevel) level(), pos);
     }
 
     /**
@@ -56,7 +54,7 @@ public class CursorInfectorEntity extends CursorEntity
     @Override
     protected void transformBlock(BlockPos pos)
     {
-        SculkHorde.blockInfestationTable.infectBlock((ServerLevel) this.level(), pos);
+        BlockInfestationHelper.tryToInfestBlock((ServerLevel) level(), pos);
     }
 
     @Override

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
@@ -3,6 +3,7 @@ package com.github.sculkhorde.common.entity.infection;
 import com.github.sculkhorde.core.ModBlocks;
 import com.github.sculkhorde.core.ModConfig;
 import com.github.sculkhorde.util.BlockAlgorithms;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.core.BlockPos;
@@ -39,17 +40,15 @@ public class CursorSurfaceInfectorEntity extends CursorInfectorEntity{
         {
             return true;
         }
+        else if(state.isAir())
+        {
+            return true;
+        }
         else if(isExposedToInfestationWardBlock((ServerLevel) this.level(), pos))
         {
             return true;
         }
-
-        if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
-        {
-            return true;
-        }
-
-        if(state.isAir())
+        else if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return true;
         }
@@ -66,11 +65,14 @@ public class CursorSurfaceInfectorEntity extends CursorInfectorEntity{
             return true;
         }
 
-        if(!BlockAlgorithms.isExposedToAir((ServerLevel) this.level(), pos) && !state.is(ModBlocks.SCULK_ARACHNOID.get()) && !state.is(ModBlocks.SCULK_DURA_MATTER.get()))
+        boolean isBlockNotExposedToAir = !BlockAlgorithms.isExposedToAir((ServerLevel) this.level(), pos);
+        boolean isBlockNotSculkArachnoid = !state.is(ModBlocks.SCULK_ARACHNOID.get());
+        boolean isBlockNotSculkDuraMatter = !state.is(ModBlocks.SCULK_DURA_MATTER.get());
+
+        if(isBlockNotExposedToAir && isBlockNotSculkArachnoid && isBlockNotSculkDuraMatter)
         {
             return true;
         }
-
 
         return false;
     }

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
@@ -43,10 +43,6 @@ public class CursorSurfaceInfectorEntity extends CursorInfectorEntity{
         {
             return true;
         }
-        else if(!state.isSolidRender(this.level(), pos))
-        {
-            return true;
-        }
 
         if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfacePurifierEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfacePurifierEntity.java
@@ -4,8 +4,8 @@ import com.github.sculkhorde.core.ModBlocks;
 import com.github.sculkhorde.core.ModEntities;
 import com.github.sculkhorde.core.SculkHorde;
 import com.github.sculkhorde.util.BlockAlgorithms;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.core.Direction;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.entity.EntityType;
@@ -44,7 +44,7 @@ public class CursorSurfacePurifierEntity extends CursorEntity{
     @Override
     protected boolean isTarget(BlockState state, BlockPos pos)
     {
-        return SculkHorde.blockInfestationTable.isCurable(state);
+        return BlockInfestationHelper.isCurable(state);
     }
 
     /**
@@ -54,23 +54,11 @@ public class CursorSurfacePurifierEntity extends CursorEntity{
     @Override
     protected void transformBlock(BlockPos pos)
     {
-        SculkHorde.blockInfestationTable.cureBlock((ServerLevel) this.level(), pos);
-
-        if(shouldBeRemovedFromAboveBlock.test(this.level().getBlockState(pos.above())))
-        {
-            this.level().setBlockAndUpdate(pos.above(), Blocks.AIR.defaultBlockState());
-        }
-
-        boolean canCuredBlockSustatinPlant = this.level().getBlockState(pos).canSustainPlant(this.level(), pos, Direction.UP, (IPlantable) Blocks.POPPY);
-        Random rand = new Random();
-        if(rand.nextBoolean() && canCuredBlockSustatinPlant && this.level().getBlockState(pos.above()).isAir())
-        {
-            this.level().setBlockAndUpdate(pos.above(), Blocks.GRASS.defaultBlockState());
-        }
+        BlockInfestationHelper.tryToCureBlock((ServerLevel) this.level(), pos);
 
         // Get all infector cursor entities in area and kill them
         Predicate<CursorInfectorEntity> isCursor = Objects::nonNull;
-        List<CursorInfectorEntity> Infectors = level().getEntitiesOfClass(CursorInfectorEntity.class, this.getBoundingBox().inflate(5.0D), isCursor);
+        List<CursorInfectorEntity> Infectors = this.level().getEntitiesOfClass(CursorInfectorEntity.class, this.getBoundingBox().inflate(5.0D), isCursor);
         for(CursorInfectorEntity infector : Infectors)
         {
             infector.discard();
@@ -118,69 +106,4 @@ public class CursorSurfacePurifierEntity extends CursorEntity{
 
         return false;
     }
-
-
-    /**
-     * Determines if a blockstate is considered to be sculk Flora
-     * @return True if Valid, False otherwise
-     */
-    public static Predicate<BlockState> shouldBeRemovedFromAboveBlock = (b) ->
-    {
-        if (b.is(ModBlocks.GRASS.get()))
-        {
-            return true;
-        }
-
-        if(b.is(ModBlocks.GRASS_SHORT.get()))
-        {
-            return true;
-        }
-
-        if( b.is(ModBlocks.SMALL_SHROOM.get()))
-        {
-            return true;
-        }
-
-        if( b.is(ModBlocks.SCULK_SHROOM_CULTURE.get()))
-        {
-            return true;
-        }
-
-        if( b.is(ModBlocks.SPIKE.get()))
-        {
-            return true;
-        }
-
-        if( b.is(ModBlocks.SCULK_SUMMONER_BLOCK.get()))
-        {
-            return true;
-        }
-
-        if(b.is(Blocks.SCULK_CATALYST))
-        {
-            return true;
-        }
-
-        if(b.is(Blocks.SCULK_SHRIEKER))
-        {
-            return true;
-        }
-
-        if(b.is(Blocks.SCULK_VEIN))
-        {
-            return true;
-        }
-
-        if(b.is(Blocks.SCULK_SENSOR))
-        {
-            return true;
-        }
-
-        if(b.is(ModBlocks.TENDRILS.get()))
-        {
-            return true;
-        }
-
-        return false;
-    };
 }

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfacePurifierEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfacePurifierEntity.java
@@ -94,10 +94,6 @@ public class CursorSurfacePurifierEntity extends CursorEntity{
     @Override
     protected boolean isObstructed(BlockState state, BlockPos pos)
     {
-        if(!state.isSolidRender(this.level(), pos))
-        {
-            return true;
-        }
 
         if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/SculkNodeInfectionHandler.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/SculkNodeInfectionHandler.java
@@ -2,6 +2,7 @@ package com.github.sculkhorde.common.entity.infection;
 
 import com.github.sculkhorde.core.ModConfig;
 import com.github.sculkhorde.core.SculkHorde;
+import com.github.sculkhorde.util.BlockAlgorithms;
 import com.github.sculkhorde.util.TickUnits;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
@@ -72,7 +73,7 @@ public class SculkNodeInfectionHandler {
         while(checkPosition.getY() < world.getMaxBuildHeight())
         {
             checkPosition.setY(checkPosition.getY() + 1);
-            if(world.getBlockState(checkPosition).isSolid() && world.getBlockState(checkPosition).canOcclude())
+            if(BlockAlgorithms.isSolid(world, checkPosition))
             {
                 lastKnownSolidBlock = checkPosition.immutable();
             }

--- a/src/main/java/com/github/sculkhorde/common/entity/projectile/PurificationFlaskProjectileEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/projectile/PurificationFlaskProjectileEntity.java
@@ -75,6 +75,8 @@ public class PurificationFlaskProjectileEntity extends CustomItemProjectileEntit
     protected void onHit(HitResult result) {
         super.onHit(result);
 
+        if(level().isClientSide()) { return; }
+
         // If any entities are close to the impact, remove the infection from them.
         for(LivingEntity entity : level().getEntitiesOfClass(LivingEntity.class, getBoundingBox().inflate(4.0D)))
         {
@@ -87,7 +89,7 @@ public class PurificationFlaskProjectileEntity extends CustomItemProjectileEntit
 
         ArrayList<BlockPos> list = BlockAlgorithms.getBlockPosInCircle(BlockPos.containing(result.getLocation()), 3, true);
         Collections.shuffle(list);
-        list.removeIf(pos -> !level().getBlockState(pos).isSolidRender(level(), pos));
+        list.removeIf(pos -> BlockAlgorithms.isNotSolid((ServerLevel) level(), pos));
 
         for(int i = 0; i < 5 && i < list.size(); i++)
         {

--- a/src/main/java/com/github/sculkhorde/common/structures/procedural/PlannedBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/structures/procedural/PlannedBlock.java
@@ -1,10 +1,10 @@
 package com.github.sculkhorde.common.structures.procedural;
 
 import com.github.sculkhorde.core.SculkHorde;
+import com.github.sculkhorde.util.BlockInfestationHelper;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
@@ -44,8 +44,7 @@ public class PlannedBlock
         }
         // Explicit Allow
         if(
-                SculkHorde.blockInfestationTable.isInfectable(validBlocksPredicate)
-                || SculkHorde.blockInfestationTable.isCurable(validBlocksPredicate)
+                BlockInfestationHelper.isCurable(validBlocksPredicate)
                 || validBlocksPredicate.is(BlockTags.REPLACEABLE)
                 || validBlocksPredicate.is(BlockTags.NEEDS_IRON_TOOL)
                 || validBlocksPredicate.is(BlockTags.NEEDS_STONE_TOOL)

--- a/src/main/java/com/github/sculkhorde/core/ModBlockEntities.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlockEntities.java
@@ -1,7 +1,17 @@
 package com.github.sculkhorde.core;
 
-import com.github.sculkhorde.common.blockentity.*;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import com.github.sculkhorde.common.blockentity.DevMassInfectinator3000BlockEntity;
+import com.github.sculkhorde.common.blockentity.DevStructureTesterBlockEntity;
+import com.github.sculkhorde.common.blockentity.InfestedTagBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkAncientNodeBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkBeeNestBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkBeeNestCellBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkLivingRockRootBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkMassBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkNodeBlockEntity;
+import com.github.sculkhorde.common.blockentity.SculkSummonerBlockEntity;
+import com.github.sculkhorde.common.blockentity.SoulHarvesterBlockEntity;
+
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -57,6 +67,10 @@ public class ModBlockEntities {
     public static RegistryObject<BlockEntityType<InfestedTagBlockEntity>> INFESTED_WOOD_MASS_BLOCK_ENTITY =
             BLOCK_ENTITIES.register("infested_wood_mass_block_entity", () -> BlockEntityType.Builder.of(
                     InfestedTagBlockEntity::new, ModBlocks.INFESTED_WOOD_MASS.get()).build(null));
+    
+    public static RegistryObject<BlockEntityType<InfestedTagBlockEntity>> INFESTED_WOOD_STAIRS_BLOCK_ENTITY =
+    		BLOCK_ENTITIES.register("infested_wood_stairs_block_entity", () -> BlockEntityType.Builder.of(
+    				InfestedTagBlockEntity::new, ModBlocks.INFESTED_WOOD_STAIRS.get()).build(null));
 
     public static RegistryObject<BlockEntityType<SoulHarvesterBlockEntity>> SOUL_HARVESTER_BLOCK_ENTITY =
             BLOCK_ENTITIES.register("soul_harvester_block_entity", () -> BlockEntityType.Builder.of(

--- a/src/main/java/com/github/sculkhorde/core/ModBlocks.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlocks.java
@@ -1,23 +1,41 @@
 package com.github.sculkhorde.core;
 
-import com.github.sculkhorde.common.block.*;
+import java.util.function.Supplier;
+
+import com.github.sculkhorde.common.block.DevMassInfectinator3000Block;
+import com.github.sculkhorde.common.block.DevStructureTesterBlock;
+import com.github.sculkhorde.common.block.InfestedStairBlock;
+import com.github.sculkhorde.common.block.InfestedTagBlock;
+import com.github.sculkhorde.common.block.SculkAncientNodeBlock;
+import com.github.sculkhorde.common.block.SculkBeeNestBlock;
+import com.github.sculkhorde.common.block.SculkBeeNestCellBlock;
+import com.github.sculkhorde.common.block.SculkFloraBlock;
+import com.github.sculkhorde.common.block.SculkLivingRockBlock;
+import com.github.sculkhorde.common.block.SculkLivingRockRootBlock;
+import com.github.sculkhorde.common.block.SculkMassBlock;
+import com.github.sculkhorde.common.block.SculkNodeBlock;
+import com.github.sculkhorde.common.block.SculkShroomCultureBlock;
+import com.github.sculkhorde.common.block.SculkSummonerBlock;
+import com.github.sculkhorde.common.block.SmallShroomBlock;
+import com.github.sculkhorde.common.block.SoulHarvesterBlock;
+import com.github.sculkhorde.common.block.SpikeBlock;
+import com.github.sculkhorde.common.block.TendrilsBlock;
+
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
-import java.util.function.Supplier;
-
 public class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, SculkHorde.MOD_ID);
-
+    
 	//Method to Register Blocks & Register them as items
 	private static <T extends Block> RegistryObject<T> registerBlock(String name, Supplier<T> block)
 	{
@@ -498,6 +516,15 @@ public class ModBlocks {
 
 	public static final RegistryObject<InfestedTagBlock> INFESTED_WOOD_MASS =
 			registerBlock("infested_wood_mass", () -> new InfestedTagBlock(BlockBehaviour.Properties.of()
+					.mapColor(MapColor.QUARTZ)
+					.strength(15f, 30f)//Hardness & Resistance
+					.destroyTime(5f)
+					.requiresCorrectToolForDrops()
+					.sound(SoundType.WOOD)
+			));
+	
+	public static final RegistryObject<InfestedStairBlock> INFESTED_WOOD_STAIRS =
+			registerBlock("infested_wood_stairs", () -> new InfestedStairBlock(BlockBehaviour.Properties.of()
 					.mapColor(MapColor.QUARTZ)
 					.strength(15f, 30f)//Hardness & Resistance
 					.destroyTime(5f)

--- a/src/main/java/com/github/sculkhorde/core/ModBlocks.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlocks.java
@@ -523,6 +523,15 @@ public class ModBlocks {
 					.requiresCorrectToolForDrops()
 					.sound(SoundType.STONE)
 			));
+	
+	public static final RegistryObject<StairBlock> INFESTED_MOSSY_COBBLESTONE_STAIRS =
+			registerBlock("infested_mossy_cobblestone_stairs", () -> new StairBlock(() -> StairBlock.stateById(0), BlockBehaviour.Properties.of()
+					.mapColor(MapColor. STONE)
+					.strength(15f, 30f)//Hardness & Resistance
+					.destroyTime(5f)
+					.requiresCorrectToolForDrops()
+					.sound(SoundType.STONE)
+			));
 
 	public static final RegistryObject<Block> INFESTED_CLAY =
 			registerBlock("infested_clay", () -> new Block(BlockBehaviour.Properties.of()

--- a/src/main/java/com/github/sculkhorde/core/ModBlocks.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlocks.java
@@ -27,6 +27,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.registries.DeferredRegister;
@@ -390,6 +391,15 @@ public class ModBlocks {
 
 	public static final RegistryObject<Block> INFESTED_COBBLESTONE =
 			registerBlock("infested_cobblestone", () -> new Block(BlockBehaviour.Properties.of()
+					.mapColor(MapColor.TERRACOTTA_BLUE)
+					.strength(15f, 30f)//Hardness & Resistance
+					.destroyTime(5f)
+					.requiresCorrectToolForDrops()
+					.sound(SoundType.STONE)
+			));
+	
+	public static final RegistryObject<StairBlock> INFESTED_COBBLESTONE_STAIRS =
+			registerBlock("infested_cobblestone_stairs", () -> new StairBlock(() -> StairBlock.stateById(0), BlockBehaviour.Properties.of()
 					.mapColor(MapColor.TERRACOTTA_BLUE)
 					.strength(15f, 30f)//Hardness & Resistance
 					.destroyTime(5f)

--- a/src/main/java/com/github/sculkhorde/core/ModBlocks.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlocks.java
@@ -110,6 +110,15 @@ public class ModBlocks {
 					.requiresCorrectToolForDrops()
 					.sound(SoundType.ANCIENT_DEBRIS)
 			));
+	
+	public static final RegistryObject<StairBlock> INFESTED_STONE_STAIRS =
+			registerBlock("infested_stone_stairs", () -> new StairBlock(() -> StairBlock.stateById(0), BlockBehaviour.Properties.of()
+					.mapColor(MapColor.TERRACOTTA_BLACK)
+					.strength(15f, 30f)//Hardness & Resistance
+					.destroyTime(5f)
+					.requiresCorrectToolForDrops()
+					.sound(SoundType.ANCIENT_DEBRIS)
+			));
 
 	public static final RegistryObject<InfestedTagBlock> INFESTED_LOG =
 			registerBlock("infested_log", () -> new InfestedTagBlock(BlockBehaviour.Properties.of()

--- a/src/main/java/com/github/sculkhorde/core/SculkHorde.java
+++ b/src/main/java/com/github/sculkhorde/core/SculkHorde.java
@@ -11,6 +11,9 @@ import com.github.sculkhorde.util.ChunkLoading.EntityChunkLoaderHelper;
 import com.github.sculkhorde.util.DeathAreaInvestigator;
 import com.github.sculkhorde.util.StatisticsData;
 import com.mojang.logging.LogUtils;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.item.Tiers;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -33,7 +36,12 @@ public class SculkHorde {
     public static EntityFactory entityFactory = new EntityFactory();
     public static Gravemind gravemind;
     public static ModSavedData savedData;
-    public static BlockInfestationTable blockInfestationTable;
+    public static BlockInfestationTable explicitInfectableBlocks;
+    public static BlockInfestationTable tagInfectableBlocks;
+    public static BlockInfestationTable tagInfectableStairsAndSlabsBlocks;
+
+    public static BlockInfestationTable[] INFESTATION_TABLES;
+
     public static PoolBlocks randomSculkFlora;
     public static DeathAreaInvestigator deathAreaInvestigator;
     public static RaidHandler raidHandler;
@@ -79,6 +87,5 @@ public class SculkHorde {
         DEBUG_MODE = debugMode;
         savedData.setDirty();
     }
-
 
 }

--- a/src/main/java/com/github/sculkhorde/util/BlockInfestationHelper.java
+++ b/src/main/java/com/github/sculkhorde/util/BlockInfestationHelper.java
@@ -1,0 +1,336 @@
+package com.github.sculkhorde.util;
+
+import com.github.sculkhorde.common.block.InfestationEntries.BlockInfestationTable;
+import com.github.sculkhorde.common.block.InfestationEntries.IBlockInfestationEntry;
+import com.github.sculkhorde.common.block.SculkNodeBlock;
+import com.github.sculkhorde.common.blockentity.SculkBeeNestBlockEntity;
+import com.github.sculkhorde.common.entity.infection.CursorInfectorEntity;
+import com.github.sculkhorde.core.ModBlocks;
+import com.github.sculkhorde.core.SculkHorde;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Tiers;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.IPlantable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.function.Predicate;
+
+public class BlockInfestationHelper {
+
+    public static void initializeInfestationTables()
+    {
+        // Used to infect blocks that are explicitly listed. Order Matters
+        SculkHorde.explicitInfectableBlocks = new BlockInfestationTable(false);
+
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.DIRT, Blocks.SCULK.defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.COARSE_DIRT, Blocks.SCULK.defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.GRASS_BLOCK, Blocks.SCULK.defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.DIRT_PATH, Blocks.SCULK.defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.PODZOL, Blocks.SCULK.defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.CLAY, ModBlocks.INFESTED_CLAY.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.STONE, ModBlocks.INFESTED_STONE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.STONE_STAIRS, ModBlocks.INFESTED_STONE_STAIRS.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.DEEPSLATE, ModBlocks.INFESTED_DEEPSLATE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.COBBLED_DEEPSLATE, ModBlocks.INFESTED_COBBLED_DEEPSLATE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.SAND, ModBlocks.INFESTED_SAND.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.SANDSTONE, ModBlocks.INFESTED_SANDSTONE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.RED_SAND, ModBlocks.INFESTED_RED_SAND.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.DIORITE, ModBlocks.INFESTED_DIORITE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.GRANITE, ModBlocks.INFESTED_GRANITE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.ANDESITE, ModBlocks.INFESTED_ANDESITE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.TUFF, ModBlocks.INFESTED_TUFF.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.CALCITE, ModBlocks.INFESTED_CALCITE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.COBBLESTONE, ModBlocks.INFESTED_COBBLESTONE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.COBBLESTONE_STAIRS, ModBlocks.INFESTED_COBBLESTONE_STAIRS.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MOSSY_COBBLESTONE, ModBlocks.INFESTED_MOSSY_COBBLESTONE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MOSSY_COBBLESTONE_STAIRS, ModBlocks.INFESTED_MOSSY_COBBLESTONE_STAIRS.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.GRAVEL, ModBlocks.INFESTED_GRAVEL.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MUD, ModBlocks.INFESTED_MUD.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.PACKED_MUD, ModBlocks.INFESTED_PACKED_MUD.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MUD_BRICKS, ModBlocks.INFESTED_MUD_BRICKS.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.SNOW_BLOCK, ModBlocks.INFESTED_SNOW.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MOSS_BLOCK, ModBlocks.INFESTED_MOSS.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.TERRACOTTA, ModBlocks.INFESTED_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.BLACK_TERRACOTTA, ModBlocks.INFESTED_BLACK_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.BLUE_TERRACOTTA, ModBlocks.INFESTED_BLUE_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.BROWN_TERRACOTTA, ModBlocks.INFESTED_BROWN_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.CYAN_TERRACOTTA, ModBlocks.INFESTED_CYAN_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.GRAY_TERRACOTTA, ModBlocks.INFESTED_GRAY_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.GREEN_TERRACOTTA, ModBlocks.INFESTED_GREEN_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.LIGHT_BLUE_TERRACOTTA, ModBlocks.INFESTED_LIGHT_BLUE_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.LIGHT_GRAY_TERRACOTTA, ModBlocks.INFESTED_LIGHT_GRAY_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.LIME_TERRACOTTA, ModBlocks.INFESTED_LIME_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.MAGENTA_TERRACOTTA, ModBlocks.INFESTED_MAGENTA_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.ORANGE_TERRACOTTA, ModBlocks.INFESTED_ORANGE_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.PINK_TERRACOTTA, ModBlocks.INFESTED_PINK_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.PURPLE_TERRACOTTA, ModBlocks.INFESTED_PURPLE_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.RED_TERRACOTTA, ModBlocks.INFESTED_RED_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.WHITE_TERRACOTTA, ModBlocks.INFESTED_WHITE_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.YELLOW_TERRACOTTA, ModBlocks.INFESTED_YELLOW_TERRACOTTA.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.CRYING_OBSIDIAN, ModBlocks.INFESTED_CRYING_OBSIDIAN.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.NETHERRACK, ModBlocks.INFESTED_NETHERRACK.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.CRIMSON_NYLIUM, ModBlocks.INFESTED_CRIMSON_NYLIUM.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.WARPED_NYLIUM, ModBlocks.INFESTED_WARPED_NYLIUM.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.BLACKSTONE, ModBlocks.INFESTED_BLACKSTONE.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.BASALT, ModBlocks.INFESTED_BASALT.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.SMOOTH_BASALT, ModBlocks.INFESTED_SMOOTH_BASALT.get().defaultBlockState());
+        SculkHorde.explicitInfectableBlocks.addEntry(Blocks.END_STONE, ModBlocks.INFESTED_ENDSTONE.get().defaultBlockState());
+
+
+
+        // Used to infect stairs and slabs. Order Matters
+        SculkHorde.tagInfectableStairsAndSlabsBlocks = new BlockInfestationTable(false);
+        SculkHorde.tagInfectableStairsAndSlabsBlocks.addEntry(BlockTags.WOODEN_STAIRS, ModBlocks.INFESTED_WOOD_STAIRS.get());
+
+        // Used to infect generic types of blocks like wood-like, stone-like, etc. Order Matters
+        SculkHorde.tagInfectableBlocks = new BlockInfestationTable(true);
+        SculkHorde.tagInfectableBlocks.addEntry(net.minecraft.tags.BlockTags.LOGS, ModBlocks.INFESTED_LOG.get());
+        SculkHorde.tagInfectableBlocks.addEntry(BlockTags.MINEABLE_WITH_AXE, ModBlocks.INFESTED_WOOD_MASS.get());
+        SculkHorde.tagInfectableBlocks.addEntry(BlockTags.MINEABLE_WITH_PICKAXE, Tiers.IRON, ModBlocks.INFESTED_STURDY_MASS.get());
+        SculkHorde.tagInfectableBlocks.addEntry(BlockTags.MINEABLE_WITH_SHOVEL, Tiers.IRON, ModBlocks.INFESTED_CRUMPLED_MASS.get());
+        SculkHorde.tagInfectableBlocks.addEntry(BlockTags.MINEABLE_WITH_HOE, Tiers.IRON, ModBlocks.INFESTED_COMPOST_MASS.get());
+
+        SculkHorde.INFESTATION_TABLES = new BlockInfestationTable[]{
+                SculkHorde.explicitInfectableBlocks,
+                SculkHorde.tagInfectableStairsAndSlabsBlocks,
+                SculkHorde.tagInfectableBlocks
+        };
+    }
+
+    public static boolean isExplicitlyNotInfectable(BlockState blockState)
+    {
+        return blockState.is(ModBlocks.BlockTags.NOT_INFESTABLE) ||
+                blockState.is(ModBlocks.BlockTags.INFESTED_BLOCK) ||
+                blockState.isAir() ||
+                blockState.hasBlockEntity();
+    }
+
+    public static boolean isInfectable(ServerLevel level, BlockPos pos)
+    {
+        BlockState blockState = level.getBlockState(pos);
+        if(isExplicitlyNotInfectable(blockState))
+        {
+            return false;
+        }
+
+        for(BlockInfestationTable table : SculkHorde.INFESTATION_TABLES)
+        {
+            if(table.canBeInfectedByThisTable(level, pos))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isCurable(BlockState blockState)
+    {
+        return blockState.is(ModBlocks.BlockTags.INFESTED_BLOCK);
+    }
+
+    public static void tryToInfestBlock(ServerLevel world, BlockPos targetPos)
+    {
+        BlockState victimBlockState = world.getBlockState(targetPos);
+        boolean wasAbleToInfestBlock = false;
+
+        if(isExplicitlyNotInfectable(victimBlockState))
+        {
+            return;
+        }
+
+        for(BlockInfestationTable table : SculkHorde.INFESTATION_TABLES)
+        {
+            if(table.canBeInfectedByThisTable(world, targetPos))
+            {
+                wasAbleToInfestBlock = table.infectBlock(world, targetPos);
+                break;
+            }
+        }
+
+
+        // If we did not successfully infect the block, return
+        if(!wasAbleToInfestBlock)
+        {
+            return;
+        }
+
+        world.sendParticles(ParticleTypes.SCULK_CHARGE_POP, targetPos.getX() + 0.5D, targetPos.getY() + 1.15D, targetPos.getZ() + 0.5D, 2, 0.2D, 0.0D, 0.2D, 0.0D);
+        world.playSound(null, targetPos, SoundEvents.SCULK_BLOCK_SPREAD, SoundSource.BLOCKS, 2.0F, 0.6F + 1.0F);
+
+        BlockInfestationHelper.removeNearbyVein(world, targetPos);
+
+        BlockInfestationHelper.placeSculkFlora(world, targetPos);
+
+        // Chance to place a sculk node above the block
+        SculkNodeBlock.tryPlaceSculkNode(world, targetPos, false);
+
+        // Chance to place a sculk bee hive above the block
+        BlockInfestationHelper.tryPlaceSculkBeeHive(world, targetPos.above());
+    }
+
+    public static boolean tryToCureBlock(ServerLevel world, BlockPos targetPos)
+    {
+        BlockState victimBlockState = world.getBlockState(targetPos);
+        boolean wasAbleToCureBlock = false;
+        BlockState getNormalVariant = null;
+
+        if(!isCurable(victimBlockState)) { return false; }
+
+        for(BlockInfestationTable table : SculkHorde.INFESTATION_TABLES)
+        {
+            getNormalVariant = table.getNormalVariant(world, targetPos, victimBlockState);
+
+            if(getNormalVariant == null) { continue; }
+
+            wasAbleToCureBlock = true;
+
+            break;
+        }
+
+        // If we did not successfully cure the block, return
+        if(!wasAbleToCureBlock)
+        {
+            return false;
+        }
+
+        // Convert Block
+        world.setBlockAndUpdate(targetPos, getNormalVariant);
+
+        if(shouldBeRemovedFromAboveBlock.test(world.getBlockState(targetPos.above())))
+        {
+            world.setBlockAndUpdate(targetPos.above(), Blocks.AIR.defaultBlockState());
+        }
+
+        boolean canCuredBlockSustatinPlant = world.getBlockState(targetPos).canSustainPlant(world, targetPos, Direction.UP, (IPlantable) Blocks.POPPY);
+        Random rand = new Random();
+        if(rand.nextBoolean() && canCuredBlockSustatinPlant && world.getBlockState(targetPos.above()).isAir())
+        {
+            world.setBlockAndUpdate(targetPos.above(), Blocks.GRASS.defaultBlockState());
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if a blockstate is considered to be sculk Flora
+     * @return True if Valid, False otherwise
+     */
+    public static Predicate<BlockState> shouldBeRemovedFromAboveBlock = (b) ->
+    {
+        if (b.is(ModBlocks.GRASS.get()))
+        {
+            return true;
+        }
+
+        if(b.is(ModBlocks.GRASS_SHORT.get()))
+        {
+            return true;
+        }
+
+        if( b.is(ModBlocks.SMALL_SHROOM.get()))
+        {
+            return true;
+        }
+
+        if( b.is(ModBlocks.SCULK_SHROOM_CULTURE.get()))
+        {
+            return true;
+        }
+
+        if( b.is(ModBlocks.SPIKE.get()))
+        {
+            return true;
+        }
+
+        if( b.is(ModBlocks.SCULK_SUMMONER_BLOCK.get()))
+        {
+            return true;
+        }
+
+        if(b.is(Blocks.SCULK_CATALYST))
+        {
+            return true;
+        }
+
+        if(b.is(Blocks.SCULK_SHRIEKER))
+        {
+            return true;
+        }
+
+        if(b.is(Blocks.SCULK_VEIN))
+        {
+            return true;
+        }
+
+        if(b.is(Blocks.SCULK_SENSOR))
+        {
+            return true;
+        }
+
+        if(b.is(ModBlocks.TENDRILS.get()))
+        {
+            return true;
+        }
+
+        return false;
+    };
+
+    public static void removeNearbyVein(ServerLevel world, BlockPos position)
+    {
+        // Update each adjacent block if it is a sculk vein
+        // This is to prevent vein from staying on blocks that it does not belong on.
+        List<BlockPos> adjacentBlockPos = BlockAlgorithms.getAdjacentNeighbors(position);
+        for(BlockPos neighbors : adjacentBlockPos)
+        {
+            BlockState blockState = world.getBlockState(neighbors);
+            if(blockState.getBlock() == ModBlocks.TENDRILS.get())
+            {
+                if(!blockState.getBlock().canSurvive(blockState, world, neighbors))
+                    world.destroyBlock(neighbors, false);
+
+            }
+        }
+    }
+
+    public static void placeSculkFlora(ServerLevel world, BlockPos position)
+    {
+        // Given a 25% chance, place down sculk flora on block
+        if (world.random.nextInt(4) <= 0)
+        {
+            BlockAlgorithms.tryPlaceSculkFlora(position.above(), world);
+        }
+    }
+
+    /**
+     * Will only place Sculk Bee Hives
+     * @param world The World to place it in
+     * @param targetPos The position to place it in
+     */
+    public static void tryPlaceSculkBeeHive(ServerLevel world, BlockPos targetPos)
+    {
+
+        //Given random chance and the target location can see the sky, create a sculk hive
+        if(new Random().nextInt(4000) <= 1 && world.getBlockState(targetPos).isAir() && world.getBlockState(targetPos.above()).isAir() && world.getBlockState(targetPos.above().above()).isAir())
+        {
+            world.setBlockAndUpdate(targetPos, ModBlocks.SCULK_BEE_NEST_BLOCK.get().defaultBlockState());
+            SculkBeeNestBlockEntity nest = (SculkBeeNestBlockEntity) world.getBlockEntity(targetPos);
+
+            //Add bees
+            nest.addFreshInfectorOccupant();
+            nest.addFreshInfectorOccupant();
+            nest.addFreshHarvesterOccupant();
+            nest.addFreshHarvesterOccupant();
+        }
+
+    }
+}

--- a/src/main/java/com/github/sculkhorde/util/Cursor.java
+++ b/src/main/java/com/github/sculkhorde/util/Cursor.java
@@ -1,19 +1,22 @@
 package com.github.sculkhorde.util;
 
-import com.github.sculkhorde.common.entity.infection.CursorEntity;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import com.github.sculkhorde.core.ModConfig;
 import com.github.sculkhorde.core.SculkHorde;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 public class Cursor {
 
@@ -144,16 +147,12 @@ public class Cursor {
      */
     protected boolean isNotObstructed(BlockState state, BlockPos pos)
     {
-        if(SculkHorde.savedData.getSculkAccumulatedMass() <= 0)
+      	if(SculkHorde.savedData.getSculkAccumulatedMass() <= 0)
         {
             return false;
         }
-
-        if(!state.isSolidRender(level, pos))
-        {
-            return false;
-        }
-        else if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
+      	
+        if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return false;
         }

--- a/src/main/java/com/github/sculkhorde/util/CursorInfector.java
+++ b/src/main/java/com/github/sculkhorde/util/CursorInfector.java
@@ -39,10 +39,6 @@ public class CursorInfector extends Cursor{
         {
             return false;
         }
-        else if(!state.isSolidRender(this.level(), pos))
-        {
-            return false;
-        }
         else if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return false;

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -98,10 +98,12 @@ public class ModEventSubscriber {
         SculkHorde.blockInfestationTable.addEntry(net.minecraft.tags.BlockTags.LOGS, ModBlocks.INFESTED_LOG.get());
 
 
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_AXE, Tiers.IRON, ModBlocks.INFESTED_WOOD_MASS.get());
+        SculkHorde.blockInfestationTable.addEntry(BlockTags.PLANKS, ModBlocks.INFESTED_WOOD_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_PICKAXE, Tiers.IRON, ModBlocks.INFESTED_STURDY_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_SHOVEL, Tiers.IRON, ModBlocks.INFESTED_CRUMPLED_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_HOE, Tiers.IRON, ModBlocks.INFESTED_COMPOST_MASS.get());
+        
+        SculkHorde.blockInfestationTable.addEntry(BlockTags.WOODEN_STAIRS, ModBlocks.INFESTED_WOOD_STAIRS.get());
 
 
         SculkHorde.randomSculkFlora = new PoolBlocks();

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -4,11 +4,9 @@ import com.github.sculkhorde.common.advancement.GravemindEvolveImmatureTrigger;
 import com.github.sculkhorde.common.advancement.SculkHordeStartTrigger;
 import com.github.sculkhorde.common.advancement.SculkNodeSpawnTrigger;
 import com.github.sculkhorde.common.block.InfestationEntries.BlockInfestationTable;
-import com.github.sculkhorde.common.block.InfestationEntries.ITagInfestedBlock;
 import com.github.sculkhorde.common.entity.*;
 import com.github.sculkhorde.common.entity.boss.sculk_enderman.SculkEndermanEntity;
 import com.github.sculkhorde.core.ModBlocks;
-import com.github.sculkhorde.core.ModConfig;
 import com.github.sculkhorde.core.ModEntities;
 import com.github.sculkhorde.core.SculkHorde;
 import com.github.sculkhorde.core.gravemind.entity_factory.EntityFactory;
@@ -43,70 +41,7 @@ public class ModEventSubscriber {
         SculkHorde.entityFactory.addEntry(ModEntities.SCULK_MITE_AGGRESSOR.get(), 6, EntityFactory.StrategicValues.Melee, Gravemind.evolution_states.Undeveloped);
         SculkHorde.entityFactory.addEntry(ModEntities.SCULK_MITE.get(), (int) SculkMiteEntity.MAX_HEALTH, EntityFactory.StrategicValues.Infector, Gravemind.evolution_states.Undeveloped);
 
-        SculkHorde.blockInfestationTable = new BlockInfestationTable();
-
-        // Add Log Tag
-        SculkHorde.blockInfestationTable.addEntry(Blocks.DIRT, Blocks.SCULK.defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.COARSE_DIRT, Blocks.SCULK.defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.GRASS_BLOCK, Blocks.SCULK.defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.PODZOL, Blocks.SCULK.defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.CLAY, ModBlocks.INFESTED_CLAY.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.STONE, ModBlocks.INFESTED_STONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.STONE_STAIRS, ModBlocks.INFESTED_STONE_STAIRS.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.DEEPSLATE, ModBlocks.INFESTED_DEEPSLATE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLED_DEEPSLATE, ModBlocks.INFESTED_COBBLED_DEEPSLATE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.SAND, ModBlocks.INFESTED_SAND.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.SANDSTONE, ModBlocks.INFESTED_SANDSTONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.RED_SAND, ModBlocks.INFESTED_RED_SAND.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.DIORITE, ModBlocks.INFESTED_DIORITE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.GRANITE, ModBlocks.INFESTED_GRANITE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.ANDESITE, ModBlocks.INFESTED_ANDESITE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.TUFF, ModBlocks.INFESTED_TUFF.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.CALCITE, ModBlocks.INFESTED_CALCITE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE, ModBlocks.INFESTED_COBBLESTONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE_STAIRS, ModBlocks.INFESTED_COBBLESTONE_STAIRS.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MOSSY_COBBLESTONE, ModBlocks.INFESTED_MOSSY_COBBLESTONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MOSSY_COBBLESTONE_STAIRS, ModBlocks.INFESTED_MOSSY_COBBLESTONE_STAIRS.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.GRAVEL, ModBlocks.INFESTED_GRAVEL.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MUD, ModBlocks.INFESTED_MUD.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.PACKED_MUD, ModBlocks.INFESTED_PACKED_MUD.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MUD_BRICKS, ModBlocks.INFESTED_MUD_BRICKS.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.SNOW_BLOCK, ModBlocks.INFESTED_SNOW.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MOSS_BLOCK, ModBlocks.INFESTED_MOSS.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.TERRACOTTA, ModBlocks.INFESTED_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.BLACK_TERRACOTTA, ModBlocks.INFESTED_BLACK_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.BLUE_TERRACOTTA, ModBlocks.INFESTED_BLUE_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.BROWN_TERRACOTTA, ModBlocks.INFESTED_BROWN_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.CYAN_TERRACOTTA, ModBlocks.INFESTED_CYAN_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.GRAY_TERRACOTTA, ModBlocks.INFESTED_GRAY_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.GREEN_TERRACOTTA, ModBlocks.INFESTED_GREEN_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.LIGHT_BLUE_TERRACOTTA, ModBlocks.INFESTED_LIGHT_BLUE_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.LIGHT_GRAY_TERRACOTTA, ModBlocks.INFESTED_LIGHT_GRAY_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.LIME_TERRACOTTA, ModBlocks.INFESTED_LIME_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.MAGENTA_TERRACOTTA, ModBlocks.INFESTED_MAGENTA_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.ORANGE_TERRACOTTA, ModBlocks.INFESTED_ORANGE_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.PINK_TERRACOTTA, ModBlocks.INFESTED_PINK_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.PURPLE_TERRACOTTA, ModBlocks.INFESTED_PURPLE_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.RED_TERRACOTTA, ModBlocks.INFESTED_RED_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.WHITE_TERRACOTTA, ModBlocks.INFESTED_WHITE_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.YELLOW_TERRACOTTA, ModBlocks.INFESTED_YELLOW_TERRACOTTA.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.CRYING_OBSIDIAN, ModBlocks.INFESTED_CRYING_OBSIDIAN.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.NETHERRACK, ModBlocks.INFESTED_NETHERRACK.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.CRIMSON_NYLIUM, ModBlocks.INFESTED_CRIMSON_NYLIUM.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.WARPED_NYLIUM, ModBlocks.INFESTED_WARPED_NYLIUM.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.BLACKSTONE, ModBlocks.INFESTED_BLACKSTONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.BASALT, ModBlocks.INFESTED_BASALT.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.SMOOTH_BASALT, ModBlocks.INFESTED_SMOOTH_BASALT.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(Blocks.END_STONE, ModBlocks.INFESTED_ENDSTONE.get().defaultBlockState());
-        SculkHorde.blockInfestationTable.addEntry(net.minecraft.tags.BlockTags.LOGS, ModBlocks.INFESTED_LOG.get());
-
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.WOODEN_STAIRS, ModBlocks.INFESTED_WOOD_STAIRS.get());
-
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_AXE, ModBlocks.INFESTED_WOOD_MASS.get());
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_PICKAXE, Tiers.IRON, ModBlocks.INFESTED_STURDY_MASS.get());
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_SHOVEL, Tiers.IRON, ModBlocks.INFESTED_CRUMPLED_MASS.get());
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_HOE, Tiers.IRON, ModBlocks.INFESTED_COMPOST_MASS.get());
-
+        BlockInfestationHelper.initializeInfestationTables();
 
         SculkHorde.randomSculkFlora = new PoolBlocks();
         SculkHorde.randomSculkFlora.addEntry(Blocks.SCULK_CATALYST, 1);

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -99,13 +99,12 @@ public class ModEventSubscriber {
         SculkHorde.blockInfestationTable.addEntry(Blocks.END_STONE, ModBlocks.INFESTED_ENDSTONE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(net.minecraft.tags.BlockTags.LOGS, ModBlocks.INFESTED_LOG.get());
 
+        SculkHorde.blockInfestationTable.addEntry(BlockTags.WOODEN_STAIRS, ModBlocks.INFESTED_WOOD_STAIRS.get());
 
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.PLANKS, ModBlocks.INFESTED_WOOD_MASS.get());
+        SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_AXE, ModBlocks.INFESTED_WOOD_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_PICKAXE, Tiers.IRON, ModBlocks.INFESTED_STURDY_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_SHOVEL, Tiers.IRON, ModBlocks.INFESTED_CRUMPLED_MASS.get());
         SculkHorde.blockInfestationTable.addEntry(BlockTags.MINEABLE_WITH_HOE, Tiers.IRON, ModBlocks.INFESTED_COMPOST_MASS.get());
-        
-        SculkHorde.blockInfestationTable.addEntry(BlockTags.WOODEN_STAIRS, ModBlocks.INFESTED_WOOD_STAIRS.get());
 
 
         SculkHorde.randomSculkFlora = new PoolBlocks();

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -66,6 +66,7 @@ public class ModEventSubscriber {
         SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE, ModBlocks.INFESTED_COBBLESTONE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE_STAIRS, ModBlocks.INFESTED_COBBLESTONE_STAIRS.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.MOSSY_COBBLESTONE, ModBlocks.INFESTED_MOSSY_COBBLESTONE.get().defaultBlockState());
+        SculkHorde.blockInfestationTable.addEntry(Blocks.MOSSY_COBBLESTONE_STAIRS, ModBlocks.INFESTED_MOSSY_COBBLESTONE_STAIRS.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.GRAVEL, ModBlocks.INFESTED_GRAVEL.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.MUD, ModBlocks.INFESTED_MUD.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.PACKED_MUD, ModBlocks.INFESTED_PACKED_MUD.get().defaultBlockState());

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -52,6 +52,7 @@ public class ModEventSubscriber {
         SculkHorde.blockInfestationTable.addEntry(Blocks.PODZOL, Blocks.SCULK.defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.CLAY, ModBlocks.INFESTED_CLAY.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.STONE, ModBlocks.INFESTED_STONE.get().defaultBlockState());
+        SculkHorde.blockInfestationTable.addEntry(Blocks.STONE_STAIRS, ModBlocks.INFESTED_STONE_STAIRS.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.DEEPSLATE, ModBlocks.INFESTED_DEEPSLATE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLED_DEEPSLATE, ModBlocks.INFESTED_COBBLED_DEEPSLATE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.SAND, ModBlocks.INFESTED_SAND.get().defaultBlockState());

--- a/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
+++ b/src/main/java/com/github/sculkhorde/util/ModEventSubscriber.java
@@ -63,6 +63,7 @@ public class ModEventSubscriber {
         SculkHorde.blockInfestationTable.addEntry(Blocks.TUFF, ModBlocks.INFESTED_TUFF.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.CALCITE, ModBlocks.INFESTED_CALCITE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE, ModBlocks.INFESTED_COBBLESTONE.get().defaultBlockState());
+        SculkHorde.blockInfestationTable.addEntry(Blocks.COBBLESTONE_STAIRS, ModBlocks.INFESTED_COBBLESTONE_STAIRS.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.MOSSY_COBBLESTONE, ModBlocks.INFESTED_MOSSY_COBBLESTONE.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.GRAVEL, ModBlocks.INFESTED_GRAVEL.get().defaultBlockState());
         SculkHorde.blockInfestationTable.addEntry(Blocks.MUD, ModBlocks.INFESTED_MUD.get().defaultBlockState());

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ modId="sculkhorde" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
-version="1.20.1-0.8.0" #mandatory
+version="1.20.1-0.8.1-Beta1" #mandatory
  # A display name for the mod
 displayName="Sculk Horde" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/

--- a/src/main/resources/assets/sculkhorde/blockstates/infested_cobblestone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/blockstates/infested_cobblestone_stairs.json
@@ -1,0 +1,209 @@
+{
+  "variants": {
+    "facing=east,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner"
+    },
+    "facing=east,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer"
+    },
+    "facing=east,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs"
+    },
+    "facing=east,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=south,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner"
+    },
+    "facing=south,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer"
+    },
+    "facing=south,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    }
+  }
+}

--- a/src/main/resources/assets/sculkhorde/blockstates/infested_mossy_cobblestone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/blockstates/infested_mossy_cobblestone_stairs.json
@@ -1,0 +1,209 @@
+{
+  "variants": {
+    "facing=east,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner"
+    },
+    "facing=east,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer"
+    },
+    "facing=east,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs"
+    },
+    "facing=east,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=south,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner"
+    },
+    "facing=south,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer"
+    },
+    "facing=south,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_cobblestone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    }
+  }
+}

--- a/src/main/resources/assets/sculkhorde/blockstates/infested_stone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/blockstates/infested_stone_stairs.json
@@ -1,0 +1,209 @@
+{
+  "variants": {
+    "facing=east,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner"
+    },
+    "facing=east,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer"
+    },
+    "facing=east,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs"
+    },
+    "facing=east,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=south,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner"
+    },
+    "facing=south,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer"
+    },
+    "facing=south,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_stone_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_stone_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    }
+  }
+}

--- a/src/main/resources/assets/sculkhorde/blockstates/infested_wood_stairs.json
+++ b/src/main/resources/assets/sculkhorde/blockstates/infested_wood_stairs.json
@@ -1,0 +1,209 @@
+{
+  "variants": {
+    "facing=east,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner"
+    },
+    "facing=east,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=east,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer"
+    },
+    "facing=east,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs"
+    },
+    "facing=east,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=east,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=east,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=north,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=north,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180
+    },
+    "facing=north,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=south,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner"
+    },
+    "facing=south,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer"
+    },
+    "facing=south,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=south,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=south,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 90
+    },
+    "facing=west,half=bottom,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=bottom,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=inner_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_inner",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=outer_left": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    },
+    "facing=west,half=top,shape=outer_right": {
+      "model": "sculkhorde:block/infested_wood_stairs_outer",
+      "uvlock": true,
+      "x": 180,
+      "y": 270
+    },
+    "facing=west,half=top,shape=straight": {
+      "model": "sculkhorde:block/infested_wood_stairs",
+      "uvlock": true,
+      "x": 180,
+      "y": 180
+    }
+  }
+}

--- a/src/main/resources/assets/sculkhorde/lang/en_us.json
+++ b/src/main/resources/assets/sculkhorde/lang/en_us.json
@@ -30,6 +30,7 @@
   "block.sculkhorde.infested_cobblestone": "Infested Cobblestone",
   "block.sculkhorde.infested_cobblestone_stairs": "Infested Cobblestone Stairs",
   "block.sculkhorde.infested_stone": "Infested Stone",
+  "block.sculkhorde.infested_stone_stairs": "Infested Stone Stairs",
   "block.sculkhorde.infested_andesite": "Infested Andesite",
   "block.sculkhorde.infested_granite": "Infested Granite",
   "block.sculkhorde.infested_diorite": "Infested Diorite",

--- a/src/main/resources/assets/sculkhorde/lang/en_us.json
+++ b/src/main/resources/assets/sculkhorde/lang/en_us.json
@@ -144,6 +144,7 @@
   "block.sculkhorde.infested_crumpled_mass": "Infested Crumpled Mass",
   "block.sculkhorde.infested_compost_mass": "Infested Compost Mass",
   "block.sculkhorde.infested_wood_mass": "Infested Wood Mass",
+  "block.sculkhorde.infested_wood_stairs": "Infested Wood Stairs",
 
   "item.sculkhorde.sculk_sweeper_sword": "The Sculk Sweeper",
   "tooltip.sculkhorde.sculk_sweeper_sword": "A special sword designed to kill swarms of Sculk Mobs. Has a large sweeping edge. Only does 50% damage to non-sculk mobs. Attacking Sculk Mobs builds up a charge that can be released with right-click. This special attack will spawn Sculk Spines at the feet of Sculk Mobs. The blade is forged from the cleaver of a Sculk Enderman.",

--- a/src/main/resources/assets/sculkhorde/lang/en_us.json
+++ b/src/main/resources/assets/sculkhorde/lang/en_us.json
@@ -28,6 +28,7 @@
   "block.sculkhorde.infested_log": "Infested Log",
   "tooltip.sculkhorde.infested_log": "A material that deceivingly looks like wood, but is made of a strange, bone-like material.",
   "block.sculkhorde.infested_cobblestone": "Infested Cobblestone",
+  "block.sculkhorde.infested_cobblestone_stairs": "Infested Cobblestone Stairs",
   "block.sculkhorde.infested_stone": "Infested Stone",
   "block.sculkhorde.infested_andesite": "Infested Andesite",
   "block.sculkhorde.infested_granite": "Infested Granite",

--- a/src/main/resources/assets/sculkhorde/lang/en_us.json
+++ b/src/main/resources/assets/sculkhorde/lang/en_us.json
@@ -121,6 +121,7 @@
   "block.sculkhorde.infested_smooth_basalt": "Infested Smooth Basalt",
   "block.sculkhorde.infested_endstone": "Infested Endstone",
   "block.sculkhorde.infested_mossy_cobblestone": "Infested Mossy Cobblestone",
+  "block.sculkhorde.infested_mossy_cobblestone_stairs": "Infested Mossy Cobblestone Stairs",
 
   "item.sculkhorde.sculk_spore_spewer_spawn_egg": "Sculk Spore Spewer Spawn Egg",
   "item.sculkhorde.sculk_zombie_spawn_egg": "Sculk Zombie Spawn Egg",

--- a/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_cobblestone",
+    "side": "sculkhorde:block/infested_cobblestone",
+    "top": "sculkhorde:block/infested_cobblestone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs_inner.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs_inner.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/inner_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_cobblestone",
+    "side": "sculkhorde:block/infested_cobblestone",
+    "top": "sculkhorde:block/infested_cobblestone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs_outer.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_cobblestone_stairs_outer.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/outer_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_cobblestone",
+    "side": "sculkhorde:block/infested_cobblestone",
+    "top": "sculkhorde:block/infested_cobblestone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_stone",
+    "side": "sculkhorde:block/infested_stone",
+    "top": "sculkhorde:block/infested_stone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs_inner.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs_inner.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/inner_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_stone",
+    "side": "sculkhorde:block/infested_stone",
+    "top": "sculkhorde:block/infested_stone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs_outer.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_stone_stairs_outer.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/outer_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_stone",
+    "side": "sculkhorde:block/infested_stone",
+    "top": "sculkhorde:block/infested_stone"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_wood_mass",
+    "side": "sculkhorde:block/infested_wood_mass",
+    "top": "sculkhorde:block/infested_wood_mass"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs_inner.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs_inner.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/inner_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_wood_mass",
+    "side": "sculkhorde:block/infested_wood_mass",
+    "top": "sculkhorde:block/infested_wood_mass"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs_outer.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_wood_stairs_outer.json
@@ -1,0 +1,8 @@
+{
+  "parent": "minecraft:block/outer_stairs",
+  "textures": {
+    "bottom": "sculkhorde:block/infested_wood_mass",
+    "side": "sculkhorde:block/infested_wood_mass",
+    "top": "sculkhorde:block/infested_wood_mass"
+  }
+}

--- a/src/main/resources/assets/sculkhorde/models/item/infested_cobblestone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/item/infested_cobblestone_stairs.json
@@ -1,0 +1,3 @@
+{
+  "parent": "sculkhorde:block/infested_cobblestone_stairs"
+}

--- a/src/main/resources/assets/sculkhorde/models/item/infested_mossy_cobblestone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/item/infested_mossy_cobblestone_stairs.json
@@ -1,0 +1,3 @@
+{
+  "parent": "sculkhorde:block/infested_cobblestone_stairs"
+}

--- a/src/main/resources/assets/sculkhorde/models/item/infested_stone_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/item/infested_stone_stairs.json
@@ -1,0 +1,3 @@
+{
+  "parent": "sculkhorde:block/infested_stone_stairs"
+}

--- a/src/main/resources/assets/sculkhorde/models/item/infested_wood_stairs.json
+++ b/src/main/resources/assets/sculkhorde/models/item/infested_wood_stairs.json
@@ -1,0 +1,3 @@
+{
+  "parent": "sculkhorde:block/infested_wood_stairs"
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "sculkhorde:infested_log",
-    "sculkhorde:infested_wood_mass"
+    "sculkhorde:infested_wood_mass",
+    "sculkhorde:infested_wood_stairs"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -42,6 +42,9 @@
     "sculkhorde:infested_endstone",
     "sculkhorde:infested_mossy_cobblestone",
 
-    "sculkhorde:infested_sturdy_mass"
+    "sculkhorde:infested_sturdy_mass",
+    "sculkhorde:infested_mossy_cobblestone_stairs",
+    "sculkhorde:infested_cobblestone_stairs",
+    "sculkhorde:infested_stone_stairs"
   ]
 }

--- a/src/main/resources/data/sculkhorde/tags/blocks/infested_block.json
+++ b/src/main/resources/data/sculkhorde/tags/blocks/infested_block.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "sculkhorde:infested_log",
     "sculkhorde:infested_crying_obsidian",
     "sculkhorde:infested_cobblestone",
     "sculkhorde:infested_stone",
@@ -47,7 +46,16 @@
     "sculkhorde:infested_red_sand",
     "sculkhorde:infested_mud",
     "sculkhorde:infested_packed_mud",
+    "sculkhorde:infested_moss",
 
-    "sculkhorde:infested_moss"
+    "sculkhorde:infested_sturdy_mass",
+    "sculkhorde:infested_crumpled_mass",
+    "sculkhorde:infested_wood_mass",
+    "sculkhorde:infested_compost_mass",
+    "sculkhorde:infested_log",
+    "sculkhorde:infested_wood_stairs",
+    "sculkhorde:infested_mossy_cobblestone_stairs",
+    "sculkhorde:infested_cobblestone_stairs",
+    "sculkhorde:infested_stone_stairs"
   ]
 }


### PR DESCRIPTION
This PR adds assets for blocks that are currently not being infested (As villages and player structures currently look a little bit ugly when infested).

_Note_: In order to get blocks with blockstates (i.e. stairs) to work the `Cursor` and `InfestationTableEntry` code had to be altered slightly. 