### PR TITLE
[1.20.1] Config options for whether Sculk Nodes and raids or the Ancient Node should spawn Sculk Phantoms

### DIFF
--- a/src/main/java/com/github/sculkhorde/common/block/SculkNodeBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/block/SculkNodeBlock.java
@@ -194,7 +194,9 @@ public class SculkNodeBlock extends BaseEntityBlock implements IForgeBlock {
         level.players().forEach(player -> player.displayClientMessage(Component.literal("A Sculk Node has spawned!"), true));
         // Play sound for each player
         level.players().forEach(player -> level.playSound(null, player.blockPosition(), ModSounds.NODE_SPAWN_SOUND.get(), SoundSource.HOSTILE, 1.0F, 1.0F));
-        spawnSculkPhantomsAtTopOfWorld(level, newOrigin, 10);
+        if (ModConfig.SERVER.should_sculk_nodes_and_raids_spawn_phantoms.get()) {
+        	spawnSculkPhantomsAtTopOfWorld(level, newOrigin, 10);
+        }
     }
 
     private static void spawnSculkPhantomsAtTopOfWorld(ServerLevel level, BlockPos origin, int amount)

--- a/src/main/java/com/github/sculkhorde/common/blockentity/SculkAncientNodeBlockEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/blockentity/SculkAncientNodeBlockEntity.java
@@ -425,7 +425,9 @@ public class SculkAncientNodeBlockEntity extends BlockEntity implements GameEven
 
         level.players().forEach((player) -> level.playSound(null, player.blockPosition(), ModSounds.HORDE_START_SOUND.get(), SoundSource.AMBIENT, 1.0F, 1.0F));
 
-        spawnSculkPhantomsAtTopOfWorld(blockEntity, 10);
+		if (ModConfig.SERVER.should_ancient_node_spawn_phantoms.get()) {
+        	spawnSculkPhantomsAtTopOfWorld(blockEntity, 10);
+        }
     }
 
     // Data

--- a/src/main/java/com/github/sculkhorde/core/ModConfig.java
+++ b/src/main/java/com/github/sculkhorde/core/ModConfig.java
@@ -48,7 +48,9 @@ public class ModConfig {
         public final ForgeConfigSpec.ConfigValue<Boolean> should_sculk_mites_spawn_in_deep_dark;
 
         public final ForgeConfigSpec.ConfigValue<Boolean> should_phantoms_load_chunks;
-
+        public final ForgeConfigSpec.ConfigValue<Boolean> sculk_nodes_and_raids_spawn_phantoms;
+        public final ForgeConfigSpec.ConfigValue<Boolean> should_ancient_node_spawn_phantoms;
+        
         public final ForgeConfigSpec.ConfigValue<Boolean> sculk_raid_enabled;
         public final ForgeConfigSpec.ConfigValue<Integer> sculk_raid_enderman_scouting_duration_minutes;
         public final ForgeConfigSpec.ConfigValue<Integer> sculk_raid_global_cooldown_between_raids_minutes;
@@ -193,6 +195,8 @@ public class ModConfig {
 
             builder.push("Sculk Phantom Variables");
             should_phantoms_load_chunks = builder.comment("Should sculk phantoms load chunks? (Default true)").define("should_phantoms_load_chunks",true);
+            should_sculk_nodes_and_raids_spawn_phantoms = builder.comment("Should sculk phantoms be spawned by sculk nodes and raids? (Default true)").define("should_sculk_nodes_and_raids_spawn_phantoms",true);
+            should_ancient_node_spawn_phantoms = builder.comment("Should sculk phantoms be spawned when the ancient node is triggered? (Default true)").define("should_ancient_node_spawn_phantoms",true);
             builder.pop();
 
             builder.push("Experimental Features");

--- a/src/main/java/com/github/sculkhorde/core/gravemind/RaidHandler.java
+++ b/src/main/java/com/github/sculkhorde/core/gravemind/RaidHandler.java
@@ -431,7 +431,9 @@ public class RaidHandler {
             playSoundForEveryPlayer(ModSounds.RAID_SCOUT_SOUND.get(), 1.0F, 1.0F);
 
             //Spawn Sculk Phantoms
-            spawnSculkPhantomsAtTopOfWorld(raidData.getDimension(), raidData.getAreaOfInterestEntry().getPosition(), 5);
+            if (ModConfig.SERVER.should_sculk_nodes_and_raids_spawn_phantoms.get()) {
+            	spawnSculkPhantomsAtTopOfWorld(raidData.getDimension(), raidData.getAreaOfInterestEntry().getPosition(), 5);
+            }
         }
 
         if(!raidData.getScoutEnderman().isAlive())

--- a/src/main/java/com/github/sculkhorde/core/gravemind/events/SpawnPhantomsEvent.java
+++ b/src/main/java/com/github/sculkhorde/core/gravemind/events/SpawnPhantomsEvent.java
@@ -2,6 +2,7 @@ package com.github.sculkhorde.core.gravemind.events;
 
 
 import com.github.sculkhorde.common.entity.SculkPhantomEntity;
+import com.github.sculkhorde.core.ModConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 
@@ -39,6 +40,8 @@ public class SpawnPhantomsEvent extends Event{
     public void start()
     {
         super.start();
-        spawnScoutPhantomsAtTopOfWorld(10);
+        if (ModConfig.SERVER.should_sculk_nodes_and_raids_spawn_phantoms.get()) {
+        	spawnScoutPhantomsAtTopOfWorld(10);
+        }
     }
 }


### PR DESCRIPTION
Some extra configurability for those who want it, especially for modpack developers who may want to make Sculk Phantoms spawn in other ways.  I can separate the first config option (nodes and raids) if desired.