### PR TITLE
directional infested logs

### DIFF
--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockEntityInfestationTableEntry.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/BlockEntityInfestationTableEntry.java
@@ -69,9 +69,7 @@ public abstract class BlockEntityInfestationTableEntry implements IBlockInfestat
         // copy block properties of normal block to infected block
         BlockState infectedState = ((Block)infectedVariant).defaultBlockState();
 
-        for(Property<?> prop : level.getBlockState(blockPos).getProperties()) {
-            infectedState = copyBlockProperty(level.getBlockState(blockPos), infectedState, prop);
-        }
+        infectedState = copyBlockProperties(level.getBlockState(blockPos), infectedState);
 
         return infectedState;
     }

--- a/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/ToolTaglInfestationTableEntry.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestationEntries/ToolTaglInfestationTableEntry.java
@@ -36,9 +36,4 @@ public class ToolTaglInfestationTableEntry extends BlockEntityInfestationTableEn
 
         return blockState.is(toolRequiredTag);
     }
-
-    public BlockState getInfectedVariant(Level level, BlockPos blockPos)
-    {
-        return ((Block)infectedVariant).defaultBlockState();
-    }
 }

--- a/src/main/java/com/github/sculkhorde/common/block/InfestedPillarBlock.java
+++ b/src/main/java/com/github/sculkhorde/common/block/InfestedPillarBlock.java
@@ -1,0 +1,33 @@
+package com.github.sculkhorde.common.block;
+
+import com.github.sculkhorde.common.block.InfestationEntries.ITagInfestedBlock;
+import com.github.sculkhorde.common.block.InfestationEntries.ITagInfestedBlockEntity;
+import com.github.sculkhorde.common.blockentity.InfestedTagBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.extensions.IForgeBlock;
+
+public class InfestedPillarBlock extends RotatedPillarBlock implements EntityBlock, IForgeBlock, ITagInfestedBlock {
+
+    public InfestedPillarBlock(Properties prop) {
+        super(prop);
+    }
+
+    public BlockEntity newBlockEntity(BlockPos blockPos, BlockState state) {
+        return new InfestedTagBlockEntity(blockPos, state);
+    }
+
+    @Override
+    public ITagInfestedBlockEntity getTagInfestedBlockEntity(Level level, BlockPos blockPos) {
+        BlockEntity blockEntity = level.getBlockEntity(blockPos);
+        if(blockEntity instanceof ITagInfestedBlockEntity)
+        {
+            return (ITagInfestedBlockEntity) blockEntity;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/sculkhorde/core/ModBlocks.java
+++ b/src/main/java/com/github/sculkhorde/core/ModBlocks.java
@@ -171,8 +171,8 @@ public class ModBlocks {
 	public static final RegistryObject<SlabBlock> INFESTED_STONE_SLAB =
 			slab(INFESTED_STONE);
 
-	public static final RegistryObject<InfestedTagBlock> INFESTED_LOG =
-			registerBlock("infested_log", () -> new InfestedTagBlock(BlockBehaviour.Properties.of()
+	public static final RegistryObject<InfestedPillarBlock> INFESTED_LOG =
+			registerBlock("infested_log", () -> new InfestedPillarBlock(BlockBehaviour.Properties.of()
 					.mapColor(MapColor.QUARTZ)
 					.strength(4f, 30f)//Hardness & Resistance
 					.destroyTime(5f)

--- a/src/main/resources/assets/sculkhorde/blockstates/infested_log.json
+++ b/src/main/resources/assets/sculkhorde/blockstates/infested_log.json
@@ -1,5 +1,16 @@
 {
   "variants": {
-    "": { "model": "sculkhorde:block/infested_log" }
+    "axis=x": {
+      "model": "sculkhorde:block/infested_log_horizontal",
+      "x": 90,
+      "y": 90
+    },
+    "axis=y": {
+      "model": "sculkhorde:block/infested_log"
+    },
+    "axis=z": {
+      "model": "sculkhorde:block/infested_log_horizontal",
+      "x": 90
+    }
   }
 }

--- a/src/main/resources/assets/sculkhorde/models/block/infested_log_horizontal.json
+++ b/src/main/resources/assets/sculkhorde/models/block/infested_log_horizontal.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/cube_column_horizontal",
+  "textures": {
+    "end": "sculkhorde:block/infested_log",
+    "side": "sculkhorde:block/infested_log_side"
+  }
+}


### PR DESCRIPTION
also fixes `ToolTaglInfestationEntry`s not copying properties during infestation