### PR TITLE
fix broken wards_against_infestation tag

### DIFF
--- a/src/main/resources/data/sculkhorde/tags/blocks/wards_against_infestation.json
+++ b/src/main/resources/data/sculkhorde/tags/blocks/wards_against_infestation.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "sculkhorde:infestation_ward"
+    "sculkhorde:infestation_ward_block"
   ]
 }


### PR DESCRIPTION
adds "_block" to the end of the only tagged block as it was pointing to a non existant block causing the tag to fail loading

fixes this in logs too

<img width="996" height="85" alt="image" src="https://github.com/user-attachments/assets/c7ff0397-0551-432e-ad47-7558e185ee0c" />



