### PR TITLE
additional recipes for building blocks + extra

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -74,6 +74,7 @@
     "sculkhorde:infested_mud_bricks",
     "sculkhorde:infested_mud_brick_stairs",
     "sculkhorde:infested_mud_brick_slab",
+    "sculkhorde:infested_packed_mud",
 
     "sculkhorde:soulite_core_block",
     "sculkhorde:soulite_block",

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
@@ -7,7 +7,6 @@
     "sculkhorde:infested_gravel",
     "sculkhorde:infested_red_sand",
     "sculkhorde:infested_mud",
-    "sculkhorde:infested_packed_mud",
     "sculkhorde:infested_clay",
 
     "sculkhorde:infested_crumpled_mass",

--- a/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_clay.json
+++ b/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_clay.json
@@ -2,13 +2,49 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "sculkhorde:infested_clay"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "sculkhorde:infested_clay"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "add": false,
+                  "count": 4.0,
+                  "function": "minecraft:set_count"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "minecraft:clay_ball"
+            }
+          ]
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "sculkhorde:blocks/infested_clay"
 }

--- a/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_deepslate.json
+++ b/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_deepslate.json
@@ -2,13 +2,44 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "sculkhorde:infested_deepslate"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "sculkhorde:infested_deepslate"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "sculkhorde:infested_cobbled_deepslate"
+            }
+          ]
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "sculkhorde:blocks/infested_deepslate"
 }

--- a/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_gravel.json
+++ b/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_gravel.json
@@ -2,13 +2,65 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "sculkhorde:infested_gravel"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "sculkhorde:infested_gravel"
+            },
+            {
+              "type": "minecraft:alternatives",
+              "children": [
+                {
+                  "type": "minecraft:item",
+                  "conditions": [
+                    {
+                      "chances": [
+                        0.1,
+                        0.14285715,
+                        0.25,
+                        1.0
+                      ],
+                      "condition": "minecraft:table_bonus",
+                      "enchantment": "minecraft:fortune"
+                    }
+                  ],
+                  "name": "minecraft:flint"
+                },
+                {
+                  "type": "minecraft:item",
+                  "name": "sculkhorde:infested_gravel"
+                }
+              ],
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ]
+            }
+          ]
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "sculkhorde:blocks/infested_gravel"
 }

--- a/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_snow.json
+++ b/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_snow.json
@@ -2,13 +2,49 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "sculkhorde:infested_snow"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "sculkhorde:infested_snow"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "add": false,
+                  "count": 4.0,
+                  "function": "minecraft:set_count"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "minecraft:snowball"
+            }
+          ]
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "sculkhorde:blocks/infested_snow"
 }

--- a/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_stone.json
+++ b/src/main/resources/data/sculkhorde/loot_tables/blocks/infested_stone.json
@@ -2,13 +2,44 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "sculkhorde:infested_stone"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "sculkhorde:infested_stone"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "sculkhorde:infested_cobblestone"
+            }
+          ]
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "sculkhorde:blocks/infested_stone"
 }

--- a/src/main/resources/data/sculkhorde/recipes/infested_black_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_black_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:black_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_black_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_blackstone_bricks.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_blackstone_bricks.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "key": {
+    "S": {
+      "item": "sculkhorde:infested_blackstone"
+    }
+  },
+  "pattern": [
+    "SS",
+    "SS"
+  ],
+  "result": {
+    "count": 4,
+    "item": "sculkhorde:infested_blackstone_bricks"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_blue_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_blue_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:blue_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_blue_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_brown_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_brown_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:brown_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_brown_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_cyan_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_cyan_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:cyan_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_cyan_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_deepslate.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_deepslate.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "cookingtime": 200,
+  "experience": 0.1,
+  "ingredient": {
+    "item": "sculkhorde:infested_cobbled_deepslate"
+  },
+  "result": "sculkhorde:infested_deepslate"
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_gray_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_gray_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:gray_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_gray_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_green_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_green_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:green_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_green_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_light_blue_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_light_blue_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:light_blue_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_light_blue_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_light_gray_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_light_gray_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:light_gray_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_light_gray_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_lime_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_lime_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:lime_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_lime_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_magenta_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_magenta_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:magenta_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_magenta_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_mossy_cobblestone_from_infested_moss.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_mossy_cobblestone_from_infested_moss.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "mossy_cobblestone",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_cobblestone"
+    },
+    {
+      "item": "sculkhorde:infested_moss"
+    }
+  ],
+  "result": {
+    "item": "sculkhorde:infested_mossy_cobblestone"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_mossy_cobblestone_from_sculk_vein.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_mossy_cobblestone_from_sculk_vein.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "mossy_cobblestone",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_cobblestone"
+    },
+    {
+      "item": "minecraft:sculk_vein"
+    }
+  ],
+  "result": {
+    "item": "sculkhorde:infested_mossy_cobblestone"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_mossy_stone_bricks_from_infested_moss.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_mossy_stone_bricks_from_infested_moss.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "mossy_stone_bricks",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_stone_bricks"
+    },
+    {
+      "item": "sculkhorde:infested_moss"
+    }
+  ],
+  "result": {
+    "item": "sculkhorde:infested_mossy_stone_bricks"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_mossy_stone_bricks_from_sculk_vein.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_mossy_stone_bricks_from_sculk_vein.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "mossy_stone_bricks",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_stone_bricks"
+    },
+    {
+      "item": "minecraft:sculk_vein"
+    }
+  ],
+  "result": {
+    "item": "sculkhorde:infested_mossy_stone_bricks"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_mud_bricks.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_mud_bricks.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_packed_mud"
+    }
+  },
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "result": {
+    "count": 4,
+    "item": "sculkhorde:infested_mud_bricks"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_orange_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_orange_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:orange_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_orange_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_packed_mud.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_packed_mud.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_mud"
+    },
+    {
+      "item": "minecraft:wheat"
+    }
+  ],
+  "result": {
+    "item": "sculkhorde:infested_packed_mud"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_pink_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_pink_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:pink_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_pink_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_purple_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_purple_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:purple_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_purple_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_red_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_red_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:red_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_red_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_sandstone.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_sandstone.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_sand"
+    }
+  },
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "result": {
+    "item": "sculkhorde:infested_sandstone"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_smooth_basalt.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_smooth_basalt.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "cookingtime": 200,
+  "experience": 0.1,
+  "ingredient": {
+    "item": "sculkhorde:infested_basalt"
+  },
+  "result": "sculkhorde:infested_smooth_basalt"
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_stone.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_stone.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "cookingtime": 200,
+  "experience": 0.1,
+  "ingredient": {
+    "item": "sculkhorde:infested_cobblestone"
+  },
+  "result": "sculkhorde:infested_stone"
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_stone_bricks.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_stone_bricks.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_stone"
+    }
+  },
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "result": {
+    "count": 4,
+    "item": "sculkhorde:infested_stone_bricks"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_terracotta.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "cookingtime": 200,
+  "experience": 0.35,
+  "ingredient": {
+    "item": "sculkhorde:infested_clay"
+  },
+  "result": "sculkhorde:infested_terracotta"
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_white_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_white_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:white_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_white_terracotta"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_wood_mass.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_wood_mass.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "group": "planks",
+  "ingredients": [
+    {
+      "item": "sculkhorde:infested_log"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "item": "sculkhorde:infested_wood_mass"
+  }
+}

--- a/src/main/resources/data/sculkhorde/recipes/infested_yellow_terracotta.json
+++ b/src/main/resources/data/sculkhorde/recipes/infested_yellow_terracotta.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "group": "infested_stained_terracotta",
+  "key": {
+    "#": {
+      "item": "sculkhorde:infested_terracotta"
+    },
+    "X": {
+      "item": "minecraft:yellow_dye"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 8,
+    "item": "sculkhorde:infested_yellow_terracotta"
+  },
+  "show_notification": true
+}


### PR DESCRIPTION
finishes off the infested building block recipes in the mod and changes loot tables for infested stone, deepslate, clay, gravel, and snow to act like vanilla and fixes infested packed mud using the wrong tool to break