### PR TITLE
Fix sculk nodes getting nuke proof tags and addtional tag fixes

### DIFF
--- a/src/main/resources/data/alexscaves/tags/blocks/nuke_proof.json
+++ b/src/main/resources/data/alexscaves/tags/blocks/nuke_proof.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [],
+  "remove": [
+    "sculkhorde:sculk_node"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -15,5 +15,8 @@
     "sculkhorde:fungal_sculk_stem_block",
     "sculkhorde:infested_crafting_table_block",
     "sculkhorde:ancient_bookshelf_block"
+  ],
+  "remove": [
+    "sculkhorde:infested_sturdy_fence_gate"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/hoe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/hoe.json
@@ -3,8 +3,10 @@
   "values": [
     "sculkhorde:infested_moss",
     "sculkhorde:infested_compost_mass",
+    "sculkhorde:infested_crumpled_mass",
     "sculkhorde:infested_crumbling_stairs",
     "sculkhorde:infested_crumbling_slab",
+    "sculkhorde:infested_crumbling_wall",
     "sculkhorde:fungal_shroom_core_block",
     "sculkhorde:fungal_sculk_block",
     "sculkhorde:fungal_sculk_stem_block",

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -66,6 +66,8 @@
     "sculkhorde:infested_andesite_stairs",
     "sculkhorde:infested_sturdy_slab",
     "sculkhorde:infested_sturdy_stairs",
+    "sculkhorde:infested_sturdy_fence",
+    "sculkhorde:infested_sturdy_fence_gate",
     "sculkhorde:infested_cobbled_deepslate_slab",
     "sculkhorde:infested_cobbled_deepslate_stairs",
     "sculkhorde:infested_cobblestone_slab",
@@ -83,5 +85,8 @@
     "sculkhorde:depleted_soulite_block",
     "sculkhorde:budding_soulite_block",
     "sculkhorde:spike"
+  ],
+  "remove": [
+    "sculkhorde:infested_crumbling_wall"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
@@ -10,7 +10,7 @@
     "sculkhorde:infested_clay",
 
     "sculkhorde:infested_crumpled_mass",
-
+    "sculkhorde:infested_crumbling_wall",
     "sculkhorde:infested_crumbling_stairs",
     "sculkhorde:infested_crumbling_slab"
   ]

--- a/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
@@ -72,6 +72,7 @@
     "sculkhorde:infested_blackstone_stairs",
     "sculkhorde:infested_sturdy_stairs",
     "sculkhorde:infested_crumbling_stairs",
+    "sculkhorde:infested_wood_stairs",
     "sculkhorde:infested_mud_brick_stairs",
     "sculkhorde:infested_stone_brick_stairs",
     "sculkhorde:infested_mossy_stone_brick_stairs",


### PR DESCRIPTION
stops the sculk node from inheriting the nuke proof tag when used with alexs caves and fixes a few other small block tag issues