### PR TITLE
Make Sculk not spread outside the world border & Cursor food item tag

### DIFF
--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorEntity.java
@@ -116,6 +116,10 @@ public abstract class CursorEntity extends Entity
             return false;
         }
 
+        if (!this.level().getWorldBorder().isWithinBounds(pos)) {
+            return true;
+        }
+
         if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return true;

--- a/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
+++ b/src/main/java/com/github/sculkhorde/common/entity/infection/CursorSurfaceInfectorEntity.java
@@ -80,6 +80,10 @@ public class CursorSurfaceInfectorEntity extends CursorEntity{
         {
             return true;
         }
+        // Check if the position is within world border
+        if (!this.level().getWorldBorder().isWithinBounds(pos)) {
+            return true;
+        }
         // This is to prevent the entity from getting stuck in a loop
         else if(visitedPositons.containsKey(pos.asLong()))
         {

--- a/src/main/java/com/github/sculkhorde/core/ModConfig.java
+++ b/src/main/java/com/github/sculkhorde/core/ModConfig.java
@@ -4,7 +4,9 @@ import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
@@ -18,6 +20,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+
+import static com.github.sculkhorde.core.SculkHorde.MOD_ID;
 
 public class    ModConfig {
 
@@ -78,8 +82,6 @@ public class    ModConfig {
         public final ForgeConfigSpec.ConfigValue<Integer> sculk_raid_no_raid_zone_duration_minutes;
         public final ForgeConfigSpec.ConfigValue<Double> purification_speed_multiplier;
         public final ForgeConfigSpec.ConfigValue<Integer> infestation_purifier_range;
-        private final ForgeConfigSpec.ConfigValue<List<? extends String>> items_infection_cursors_can_eat;
-        public static final HashMap<String, Boolean> infection_cursor_item_eat_list = new HashMap<>();
 
         private final ForgeConfigSpec.ConfigValue<List<? extends String>> make_block_infestable;
         public static final HashMap<String, Boolean> manually_configured_infestable_blocks = new HashMap<>();
@@ -104,43 +106,11 @@ public class    ModConfig {
         public final ForgeConfigSpec.ConfigValue<Boolean> hit_squad_event_enabled;
         public final ForgeConfigSpec.ConfigValue<Boolean> ghast_deployment_event_enabled;
 
-        public void loadItemsInfectionCursorsCanEat()
-        {
-            infection_cursor_item_eat_list.clear();
-            for(String item : ModConfig.SERVER.items_infection_cursors_can_eat.get())
-            {
-                infection_cursor_item_eat_list.put(item, true);
-            }
-        }
-
         public boolean isItemEdibleToCursors(ItemEntity itemEntity)
         {
             ItemStack itemStack = itemEntity.getItem();
-            Item item = itemStack.getItem();
-            ResourceLocation itemResourceLocation = BuiltInRegistries.ITEM.getKey(item);
 
-
-            if(itemResourceLocation == null)
-            {
-                return false;
-            }
-
-            String itemName = itemResourceLocation.toString();
-            if(infection_cursor_item_eat_list.containsKey(itemName))
-            {
-                return true;
-            }
-
-            if(item.isEdible())
-            {
-                return true;
-            }
-
-            if (itemName.contains("sapling")) {
-                return true;
-            }
-
-            return false;
+            return itemStack.getItem().isEdible() || itemStack.is(TagKey.create(Registries.ITEM, new ResourceLocation(MOD_ID, "cursor_edible")));
         }
 
         public void loadConfiguredInfestableBlocks()
@@ -242,7 +212,6 @@ public class    ModConfig {
             infection_speed_multiplier = builder.comment("How much faster or slower should infection spread? (Default 1)").defineInRange("infection_speed_multiplier",1.0, 0.001, 10);
             max_infestation_cursor_population = builder.comment("How many infestation cursors are allowed to exist at one time. WARNING: This only applies if performance mode is at HIGH. To keep performance at HIGH, set disable_auto_performance_system to true (Default 200)").defineInRange("max_infestation_cursor_population", 200, 1, Integer.MAX_VALUE);
             infestation_purifier_range = builder.comment("How far should the infestation purifier reach? (Default 5)").defineInRange("purifier_range",48, 0, 100);
-            items_infection_cursors_can_eat = builder.comment("What dropped items should cursors eat? This prevents lag and boosts their lifespan.").defineList("items_infection_cursors_can_eat", Arrays.asList("minecraft:wheat_seeds", "minecraft:bamboo", "minecraft:stick", "minecraft:poppy", "minecraft:dandelion", "minecraft:blue_orchid", "minecraft:allium", "minecraft:azure_bluet", "minecraft:red_tulip", "minecraft:orange_tulip", "minecraft:white_tulip", "minecraft:pink_tulip", "minecraft:oxeye_daisy", "minecraft:cornflower", "minecraft:lily_of_the_valley", "minecraft:sunflower", "minecraft:lilac", "minecraft:rose_bush", "minecraft:peony", "minecraft:pink_petals"), entry -> true);
             make_block_infestable = builder.comment("Add blocks to this list to make them infestable. I.E. minecraft:dirt. Be careful what you put in here, this can potentially lead to issues. This will not work with blocks that are air, have a block entity, are already considered an infested block, or have the not infestable tag.").defineList("make_block_infestable", Arrays.asList(""), entry -> true);
             builder.pop();
 

--- a/src/main/java/com/github/sculkhorde/core/ModSavedData.java
+++ b/src/main/java/com/github/sculkhorde/core/ModSavedData.java
@@ -208,7 +208,6 @@ public class ModSavedData extends SavedData {
         DebuggerSystem.eventDebuggerModule.logInfo("ModSavedData | Loaded pathBuilderSystem Successfully.");
 
         DebuggerSystem.eventDebuggerModule.logInfo("ModSavedData | Loading list of items cursors can eat.");
-        ModConfig.SERVER.loadItemsInfectionCursorsCanEat();
         DebuggerSystem.eventDebuggerModule.logInfo("ModSavedData | Loaded list of items cursors can eat Successfully.");
         DebuggerSystem.eventDebuggerModule.logInfo("ModSavedData | Loading list of configured infestable blocks.");
         ModConfig.SERVER.loadConfiguredInfestableBlocks();

--- a/src/main/java/com/github/sculkhorde/modding_api/BlockInfestationAPI.java
+++ b/src/main/java/com/github/sculkhorde/modding_api/BlockInfestationAPI.java
@@ -293,9 +293,10 @@ public class BlockInfestationAPI {
      *
      * @param itemID the item's registry ID in the format "namespace:name" to register
      */
+    @Deprecated(forRemoval = true)
     public static void addToListOfItemsCursorsCanEat(String itemID)
     {
-        ModConfig.Server.infection_cursor_item_eat_list.put(itemID, true);
+        //not deleting this method yet so it doesn't crash any addons, but it won't do anything - Atobá
     }
 
 }

--- a/src/main/java/com/github/sculkhorde/systems/chunk_cursor_system/ChunkCursorBase.java
+++ b/src/main/java/com/github/sculkhorde/systems/chunk_cursor_system/ChunkCursorBase.java
@@ -271,7 +271,7 @@ public class ChunkCursorBase<T extends ChunkCursorBase<T>> extends VirtualCursor
                 boundingBox.contains(pos.getCenter()) &&
                 !isObstructed(serverLevel, pos) &&
                 canChange(serverLevel, pos) &&
-                !checkedBlocks.contains(pos)
+                !checkedBlocks.contains(pos) && serverLevel.getWorldBorder().isWithinBounds(pos)
         );
     }
 

--- a/src/main/java/com/github/sculkhorde/systems/cursor_system/VirtualCursor.java
+++ b/src/main/java/com/github/sculkhorde/systems/cursor_system/VirtualCursor.java
@@ -176,6 +176,10 @@ public class VirtualCursor implements ICursor{
      */
     protected boolean isObstructed(BlockState state, BlockPos pos)
     {
+        if (!this.level.getWorldBorder().isWithinBounds(pos))
+        {
+            return true;
+        }
         if(BlockAlgorithms.getBlockDistance(origin, pos) > MAX_RANGE)
         {
             return true;

--- a/src/main/java/com/github/sculkhorde/systems/infestation_systems/block_infestation_system/BlockInfestationSystem.java
+++ b/src/main/java/com/github/sculkhorde/systems/infestation_systems/block_infestation_system/BlockInfestationSystem.java
@@ -290,7 +290,9 @@ public class BlockInfestationSystem {
         boolean isNotInfestable = blockState.is(ModBlocks.BlockTags.NOT_INFESTABLE);
         boolean isAlreadyInfested = blockState.is(ModBlocks.BlockTags.INFESTED_BLOCK);
         boolean isAir = blockState.isAir();
+        boolean insideWorld = level.getWorldBorder().isWithinBounds(pos);
 
+        if(!insideWorld) { return true; }
         if(isNotInfestable) { return true; }
         if(isAlreadyInfested) { return true; }
         if(isAir) { return true; }

--- a/src/main/resources/data/sculkhorde/tags/items/cursor_edible.json
+++ b/src/main/resources/data/sculkhorde/tags/items/cursor_edible.json
@@ -4,6 +4,7 @@
     "#minecraft:flowers",
     "#minecraft:tall_flowers",
     "minecraft:bamboo",
+    "#minecraft:saplings",
     {
       "required": false,
       "id": "#forge:seeds"

--- a/src/main/resources/data/sculkhorde/tags/items/cursor_edible.json
+++ b/src/main/resources/data/sculkhorde/tags/items/cursor_edible.json
@@ -1,0 +1,28 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:flowers",
+    "#minecraft:tall_flowers",
+    "minecraft:bamboo",
+    {
+      "required": false,
+      "id": "#forge:seeds"
+    },
+    {
+      "required": false,
+      "id": "#forge:fruits"
+    },
+    {
+      "required": false,
+      "id": "#forge:crops"
+    },
+    {
+      "required": false,
+      "id": "#forge:vegetables"
+    },
+    {
+      "required": false,
+      "id": "#forge:raw_meat"
+    }
+  ]
+}


### PR DESCRIPTION
Makes Sculk not spread outside world border by checking `WorldBorder.isWithinBounds(BlockPos)`. 
I think I got all the relevant parts related to spreading/block infection. I think.

Removed `infection_cursor_item_eat_list ` config in favor of a tag. Deprecated `BlockInfestationAPI.addToListOfItemsCursorsCanEat` and adjusted `ModConfig.isItemEdibleToCursors`